### PR TITLE
Page Support

### DIFF
--- a/src/components/Content/Content.js
+++ b/src/components/Content/Content.js
@@ -1,0 +1,13 @@
+import ClassName from 'models/classname';
+
+import styles from './Content.module.scss';
+
+const Content = ({ children, className }) => {
+  const contentClassName = new ClassName(styles.content);
+
+  contentClassName.addIf(className, className);
+
+  return <div className={contentClassName.toString()}>{children}</div>;
+};
+
+export default Content;

--- a/src/components/Content/Content.module.scss
+++ b/src/components/Content/Content.module.scss
@@ -1,0 +1,24 @@
+@import "styles/settings/__settings";
+
+.content {
+  font-size: 1.5rem;
+
+  h2,
+  h3,
+  h4,
+  p,
+  ul {
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  img {
+    display: block;
+    margin: 0 auto;
+  }
+}

--- a/src/components/Content/index.js
+++ b/src/components/Content/index.js
@@ -1,0 +1,1 @@
+export { default } from './Content';

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -7,7 +7,7 @@ import Nav from 'components/Nav';
 import Main from 'components/Main';
 import Footer from 'components/Footer';
 
-const Layout = ({ children, displayNav = true }) => {
+const Layout = ({ children }) => {
   const { homepage, metadata = {} } = useSite();
   const { name } = metadata;
 
@@ -28,7 +28,7 @@ const Layout = ({ children, displayNav = true }) => {
         <meta property="og:site_name" content={pageTitle} />
       </Helmet>
 
-      {displayNav && <Nav />}
+      <Nav />
 
       <Main>{children}</Main>
 

--- a/src/components/Metadata/Metadata.js
+++ b/src/components/Metadata/Metadata.js
@@ -1,0 +1,19 @@
+import { format } from 'date-fns';
+
+import ClassName from 'models/classname';
+
+import styles from './Metadata.module.scss';
+
+const Metadata = ({ className, date }) => {
+  const metadataClassName = new ClassName(styles.metadata);
+
+  metadataClassName.addIf(className, className);
+
+  return (
+    <ul className={metadataClassName.toString()}>
+      <time dateTime={date}>{format(new Date(date), 'PPP')}</time>
+    </ul>
+  );
+};
+
+export default Metadata;

--- a/src/components/Metadata/Metadata.module.scss
+++ b/src/components/Metadata/Metadata.module.scss
@@ -1,0 +1,12 @@
+@import "styles/settings/__settings";
+
+.metadata {
+  color: $color-gray-600;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    display: inline-block;
+  }
+}

--- a/src/components/Metadata/index.js
+++ b/src/components/Metadata/index.js
@@ -1,0 +1,1 @@
+export { default } from './Metadata';

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -107,11 +107,7 @@ const Nav = () => {
             return (
               <li key={slug}>
                 <Link href={pagePathBySlug(slug)}>
-                  <a
-                    dangerouslySetInnerHTML={{
-                      __html: title.rendered,
-                    }}
-                  />
+                  <a>{title}</a>
                 </Link>
               </li>
             );

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -4,6 +4,8 @@ import { FaSearch } from 'react-icons/fa';
 
 import useSite from 'hooks/use-site';
 import useSearch from 'hooks/use-search';
+import { postPathBySlug } from 'lib/posts';
+import { pagePathBySlug } from 'lib/pages';
 
 import Section from 'components/Section';
 
@@ -17,7 +19,7 @@ const Nav = () => {
 
   const [searchVisibility, setSearchVisibility] = useState(SEARCH_HIDDEN);
 
-  const { metadata = {} } = useSite();
+  const { metadata = {}, navigation } = useSite();
   const { name } = metadata;
 
   const { query, results, search, clearSearch } = useSearch({
@@ -100,6 +102,21 @@ const Nav = () => {
         <p className={styles.navName}>
           <a href="/">{name}</a>
         </p>
+        <ul className={styles.navMenu}>
+          {navigation.map(({ slug, title = {} }) => {
+            return (
+              <li key={slug}>
+                <Link href={pagePathBySlug(slug)}>
+                  <a
+                    dangerouslySetInnerHTML={{
+                      __html: title.rendered,
+                    }}
+                  />
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
         <div className={styles.navSearch}>
           {searchVisibility === SEARCH_HIDDEN && (
             <button onClick={handleOnToggleSearch}>
@@ -124,7 +141,7 @@ const Nav = () => {
                     {results.map(({ slug, title }) => {
                       return (
                         <li key={slug}>
-                          <Link href={`/posts/${slug}`}>
+                          <Link href={postPathBySlug(slug)}>
                             <a>{title}</a>
                           </Link>
                         </li>

--- a/src/components/Nav/Nav.module.scss
+++ b/src/components/Nav/Nav.module.scss
@@ -23,22 +23,29 @@
 }
 
 .navName {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   flex-shrink: 0;
+  flex-grow: 1;
   margin: 0.8em 0 0;
 
   @media (min-width: 480px) {
+    justify-content: flex-start;
     margin-top: 0;
   }
 
   a {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     color: $color-gray-400;
     font-size: 1.2rem;
     font-weight: bold;
     text-decoration: none;
     border-bottom: solid 2px transparent;
+
+    @media (min-width: 480px) {
+      padding: 0.5em;
+      margin-left: -0.5em;
+    }
 
     &:hover {
       color: $color-primary;
@@ -46,7 +53,44 @@
   }
 }
 
+.navMenu {
+  display: flex;
+  align-items: center;
+  flex-grow: 0;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    margin: 0 0.25em;
+
+    &:first-child {
+      margin-left: 0;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+
+  a {
+    display: block;
+    text-decoration: none;
+    color: $color-gray-600;
+    font-size: 1.1em;
+    padding: 0.5em;
+
+    @media (hover: hover) {
+      &:hover {
+        color: $color-primary;
+      }
+    }
+  }
+}
+
 .navSearch {
+  flex-grow: 0;
+  margin-left: 1em;
   form {
     display: flex;
     align-items: center;
@@ -72,6 +116,7 @@
 
     svg {
       fill: $color-gray-400;
+      transform: translateY(2px);
     }
 
     &:focus {

--- a/src/components/PostCard/PostCard.js
+++ b/src/components/PostCard/PostCard.js
@@ -1,7 +1,7 @@
-import { format } from 'date-fns';
-
 import ClassName from 'models/classname';
 import { sanitizeExcerpt } from 'lib/posts';
+
+import Metadata from 'components/Metadata';
 
 import styles from './PostCard.module.scss';
 
@@ -17,9 +17,7 @@ const PostCard = ({ post }) => {
             __html: title?.rendered,
           }}
         />
-        <ul className={styles.postCardMetadata}>
-          <time dateTime={date}>{format(new Date(date), 'PPP')}</time>
-        </ul>
+        <Metadata className={styles.postCardMetadata} date={date} />
         <div
           className={styles.postCardContent}
           dangerouslySetInnerHTML={{

--- a/src/components/PostCard/PostCard.module.scss
+++ b/src/components/PostCard/PostCard.module.scss
@@ -39,12 +39,5 @@
 }
 
 .postCardMetadata {
-  color: $color-gray-600;
-  list-style: none;
-  padding: 0;
   margin: 1.2em 0;
-
-  li {
-    display: inline-block;
-  }
 }

--- a/src/data/pages.js
+++ b/src/data/pages.js
@@ -1,0 +1,30 @@
+import { gql } from '@apollo/client';
+
+export const QUERY_ALL_PAGES = gql`
+  {
+    pages(first: 10000) {
+      edges {
+        node {
+          content
+          id
+          menuOrder
+          slug
+          title
+        }
+      }
+    }
+  }
+`;
+
+export function getQueryPageById(id) {
+  return gql`
+    query {
+      page(id: "${id}") {
+        title
+        slug
+        menuOrder
+        content
+      }
+    }
+  `;
+}

--- a/src/data/routes.js
+++ b/src/data/routes.js
@@ -1,3 +1,2 @@
 export const WP_API_ROUTE_PREFIX = '/wp/v2';
 export const WP_API_ROUTE_POSTS = `${WP_API_ROUTE_PREFIX}/posts`;
-export const WP_API_ROUTE_PAGES = `${WP_API_ROUTE_PREFIX}/pages`;

--- a/src/data/wordpress.js
+++ b/src/data/wordpress.js
@@ -1,0 +1,3 @@
+export const WP_API_ROUTE_PREFIX = '/wp/v2';
+export const WP_API_ROUTE_POSTS = `${WP_API_ROUTE_PREFIX}/posts`;
+export const WP_API_ROUTE_PAGES = `${WP_API_ROUTE_PREFIX}/pages`;

--- a/src/hooks/use-apollo-client.js
+++ b/src/hooks/use-apollo-client.js
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+
+import { initializeApollo } from 'lib/apollo-client';
+
+export default function useApolloClient(initialState) {
+  const store = useMemo(() => initializeApollo(initialState), [initialState]);
+  return store;
+}

--- a/src/lib/apollo-client.js
+++ b/src/lib/apollo-client.js
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 import { concatPagination } from '@apollo/client/utilities';
 
@@ -6,45 +5,69 @@ let apolloClient;
 
 const WORDPRESS_HOST = process.env.WORDPRESS_HOST;
 
-function createApolloClient() {
-  return new ApolloClient({
-    ssrMode: typeof window === 'undefined',
-    link: new HttpLink({
-      uri: `${WORDPRESS_HOST}/graphql`, // Server URL (must be absolute)
-    }),
-    cache: new InMemoryCache({
-      typePolicies: {
-        Query: {
-          fields: {
-            allPosts: concatPagination(),
-          },
+/**
+ * createApolloClient
+ */
+
+export function _createApolloClient() {
+  const link = new HttpLink({
+    uri: `${WORDPRESS_HOST}/graphql`,
+  });
+
+  const cache = new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          allPosts: concatPagination(),
+          allPages: concatPagination(),
         },
       },
-    }),
+    },
+  });
+
+  return new ApolloClient({
+    ssrMode: typeof window === 'undefined',
+    link,
+    cache,
   });
 }
 
+/**
+ * initializeApollo
+ */
+
 export function initializeApollo(initialState = null) {
-  const _apolloClient = apolloClient ?? createApolloClient();
+  const _apolloClient = getApolloClient();
 
   // If your page has Next.js data fetching methods that use Apollo Client, the initial state
   // gets hydrated here
+
   if (initialState) {
     // Get existing cache, loaded during client side data fetching
+
     const existingCache = _apolloClient.extract();
+
     // Restore the cache using the data passed from getStaticProps/getServerSideProps
     // combined with the existing cached data
+
     _apolloClient.cache.restore({ ...existingCache, ...initialState });
   }
+
   // For SSG and SSR always create a new Apollo Client
+
   if (typeof window === 'undefined') return _apolloClient;
+
   // Create the Apollo Client once in the client
+
   if (!apolloClient) apolloClient = _apolloClient;
 
   return _apolloClient;
 }
 
-export function useApollo(initialState) {
-  const store = useMemo(() => initializeApollo(initialState), [initialState]);
-  return store;
+/**
+ * getApolloClient
+ */
+
+export function getApolloClient() {
+  return apolloClient ?? _createApolloClient();
 }

--- a/src/lib/pages.js
+++ b/src/lib/pages.js
@@ -1,6 +1,6 @@
-import { WP_API_ROUTE_PAGES } from 'data/wordpress';
+import { getApolloClient } from 'lib/apollo-client';
 
-import WpRequest from 'models/wp-request';
+import { QUERY_ALL_PAGES, getQueryPageById } from 'data/pages';
 
 /**
  * pagePathBySlug
@@ -11,43 +11,20 @@ export function pagePathBySlug(slug) {
 }
 
 /**
- * getPageBySlug
+ * getPageById
  */
 
-export async function getPageBySlug(slug) {
-  const request = new WpRequest({
-    route: `${WP_API_ROUTE_PAGES}?slug=${slug}`,
+export async function getPageById(id) {
+  const apolloClient = getApolloClient();
+
+  const data = await apolloClient.query({
+    query: getQueryPageById(id),
   });
 
-  const { data } = await request.fetch();
-
-  return data && data[0];
-}
-
-/**
- * getPages
- */
-
-export async function getPages({ perPage = 100, page = 1, query = {} } = {}) {
-  const params = [`per_page=${perPage}`, `page=${page}`];
-
-  Object.keys(query).forEach((key) => {
-    params.push(`${key}=${query[key]}`);
-  });
-
-  const request = new WpRequest({
-    route: `${WP_API_ROUTE_PAGES}?${params.join('&')}`,
-  });
-
-  const { data, headers } = await request.fetch();
-
-  const pages = headers['x-wp-totalpages'];
+  const page = data?.data.page;
 
   return {
-    pages: data,
-    perPage,
-    currentPage: page,
-    totalPages: parseInt(pages),
+    page,
   };
 }
 
@@ -56,24 +33,16 @@ export async function getPages({ perPage = 100, page = 1, query = {} } = {}) {
  */
 
 export async function getAllPages(options) {
-  const { pages: initialPages, totalPages } = await getPages(options);
-  const indexedArray = [...new Array(totalPages - 1)];
+  const apolloClient = getApolloClient();
 
-  const remainingPages = await Promise.all(
-    indexedArray.map(async (p, index) => {
-      const pageIndex = index + 2;
-      const { pages, totalPages } = await getPages({
-        ...options,
-        page: pageIndex,
-      });
-      return pages;
-    })
-  );
+  const data = await apolloClient.query({
+    query: QUERY_ALL_PAGES,
+  });
 
-  const allPages = [...initialPages, ...remainingPages.flat()];
+  const pages = data?.data.pages.edges.map(({ node = {} }) => node);
 
   return {
-    pages: allPages,
+    pages,
   };
 }
 
@@ -84,7 +53,7 @@ export async function getAllPages(options) {
 export async function getNavigationPages() {
   const { pages } = await getAllPages();
 
-  const navPages = pages.filter(({ menu_order: order }) => order > 0);
+  const navPages = pages.filter(({ menuOrder }) => menuOrder > 0);
 
   return navPages;
 }

--- a/src/lib/pages.js
+++ b/src/lib/pages.js
@@ -1,0 +1,90 @@
+import { WP_API_ROUTE_PAGES } from 'data/wordpress';
+
+import WpRequest from 'models/wp-request';
+
+/**
+ * pagePathBySlug
+ */
+
+export function pagePathBySlug(slug) {
+  return `/${slug}`;
+}
+
+/**
+ * getPageBySlug
+ */
+
+export async function getPageBySlug(slug) {
+  const request = new WpRequest({
+    route: `${WP_API_ROUTE_PAGES}?slug=${slug}`,
+  });
+
+  const { data } = await request.fetch();
+
+  return data && data[0];
+}
+
+/**
+ * getPages
+ */
+
+export async function getPages({ perPage = 100, page = 1, query = {} } = {}) {
+  const params = [`per_page=${perPage}`, `page=${page}`];
+
+  Object.keys(query).forEach((key) => {
+    params.push(`${key}=${query[key]}`);
+  });
+
+  const request = new WpRequest({
+    route: `${WP_API_ROUTE_PAGES}?${params.join('&')}`,
+  });
+
+  const { data, headers } = await request.fetch();
+
+  const pages = headers['x-wp-totalpages'];
+
+  return {
+    pages: data,
+    perPage,
+    currentPage: page,
+    totalPages: parseInt(pages),
+  };
+}
+
+/**
+ * getAllPages
+ */
+
+export async function getAllPages(options) {
+  const { pages: initialPages, totalPages } = await getPages(options);
+  const indexedArray = [...new Array(totalPages - 1)];
+
+  const remainingPages = await Promise.all(
+    indexedArray.map(async (p, index) => {
+      const pageIndex = index + 2;
+      const { pages, totalPages } = await getPages({
+        ...options,
+        page: pageIndex,
+      });
+      return pages;
+    })
+  );
+
+  const allPages = [...initialPages, ...remainingPages.flat()];
+
+  return {
+    pages: allPages,
+  };
+}
+
+/**
+ * getNavigationPages
+ */
+
+export async function getNavigationPages() {
+  const { pages } = await getAllPages();
+
+  const navPages = pages.filter(({ menu_order: order }) => order > 0);
+
+  return navPages;
+}

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -1,6 +1,14 @@
-const ROUTE_POSTS = '/wp/v2/posts';
+import { WP_API_ROUTE_POSTS } from 'data/wordpress';
 
 import WpRequest from 'models/wp-request';
+
+/**
+ * postPathBySlug
+ */
+
+export function postPathBySlug(slug) {
+  return `/posts/${slug}`;
+}
 
 /**
  * getPostBySlug
@@ -8,12 +16,12 @@ import WpRequest from 'models/wp-request';
 
 export async function getPostBySlug(slug) {
   const request = new WpRequest({
-    route: `${ROUTE_POSTS}?slug=${slug}`,
+    route: `${WP_API_ROUTE_POSTS}?slug=${slug}`,
   });
 
-  const { data: post } = await request.fetch();
+  const { data } = await request.fetch();
 
-  return post && post[0];
+  return data && data[0];
 }
 
 /**
@@ -28,15 +36,15 @@ export async function getPosts({ perPage = 100, page = 1, query = {} } = {}) {
   });
 
   const request = new WpRequest({
-    route: `${ROUTE_POSTS}?${params.join('&')}`,
+    route: `${WP_API_ROUTE_POSTS}?${params.join('&')}`,
   });
 
-  const { data: posts, headers } = await request.fetch();
+  const { data, headers } = await request.fetch();
 
   const pages = headers['x-wp-totalpages'];
 
   return {
-    posts,
+    posts: data,
     perPage,
     currentPage: page,
     totalPages: parseInt(pages),
@@ -48,7 +56,7 @@ export async function getPosts({ perPage = 100, page = 1, query = {} } = {}) {
  */
 
 export async function getAllPosts(options) {
-  const { posts, totalPages } = await getPosts(options);
+  const { posts: initialPosts, totalPages } = await getPosts(options);
   const indexedArray = [...new Array(totalPages - 1)];
 
   const remainingPosts = await Promise.all(
@@ -62,7 +70,7 @@ export async function getAllPosts(options) {
     })
   );
 
-  const allPosts = [...posts, ...remainingPosts.flat()];
+  const allPosts = [...initialPosts, ...remainingPosts.flat()];
 
   return {
     posts: allPosts,

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -1,4 +1,4 @@
-import { WP_API_ROUTE_POSTS } from 'data/wordpress';
+import { WP_API_ROUTE_POSTS } from 'data/routes';
 
 import WpRequest from 'models/wp-request';
 

--- a/src/lib/postsql.js
+++ b/src/lib/postsql.js
@@ -1,5 +1,5 @@
 import { gql, useQuery, NetworkStatus } from '@apollo/client';
-import { initializeApollo } from 'lib/apolloClient';
+import { initializeApollo } from 'lib/apollo-client';
 
 const GET_ALL_SLUGS = gql`
   {

--- a/src/pages/[slug].js
+++ b/src/pages/[slug].js
@@ -1,28 +1,28 @@
 import path from 'path';
 import { useRouter } from 'next/router';
 import { Helmet } from 'react-helmet';
+import { format } from 'date-fns';
 
-import { getPostBySlug, getAllPosts } from 'lib/posts';
+import { getPageBySlug, getAllPages } from 'lib/pages';
 import useSite from 'hooks/use-site';
 
 import Layout from 'components/Layout';
 import Header from 'components/Header';
+import Content from 'components/Content';
 import Section from 'components/Section';
 import Container from 'components/Container';
-import Content from 'components/Content';
-import Metadata from 'components/Metadata';
 
 import styles from 'styles/pages/Post.module.scss';
 
-export default function Post({ post }) {
+export default function Page({ page }) {
   const router = useRouter();
   const { homepage } = useSite();
 
   const { slug } = router.query;
-  const { title, content, date } = post;
+  const { title, content, date } = page;
 
   const pageTitle = title?.rendered;
-  const route = path.join(homepage, '/posts/', slug);
+  const route = path.join(homepage, '/', slug);
 
   return (
     <Layout>
@@ -40,7 +40,6 @@ export default function Post({ post }) {
             __html: title?.rendered,
           }}
         />
-        <Metadata className={styles.postMetadata} date={date} />
       </Header>
 
       <Content>
@@ -62,7 +61,7 @@ export default function Post({ post }) {
 export async function getStaticProps({ params = {} } = {}) {
   return {
     props: {
-      post: await getPostBySlug(params?.slug),
+      page: await getPageBySlug(params?.slug),
     },
   };
 }
@@ -70,10 +69,10 @@ export async function getStaticProps({ params = {} } = {}) {
 export async function getStaticPaths() {
   const routes = {};
 
-  const { posts } = await getAllPosts();
+  const { pages } = await getAllPages();
 
-  const paths = posts.map((post) => {
-    const { slug } = post;
+  const paths = pages.map((page) => {
+    const { slug } = page;
     return {
       params: {
         slug,

--- a/src/pages/[slug].js
+++ b/src/pages/[slug].js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { Helmet } from 'react-helmet';
 import { format } from 'date-fns';
 
-import { getPageBySlug, getAllPages } from 'lib/pages';
+import { getPageById, getAllPages } from 'lib/pages';
 import useSite from 'hooks/use-site';
 
 import Layout from 'components/Layout';
@@ -27,19 +27,14 @@ export default function Page({ page }) {
   return (
     <Layout>
       <Helmet>
-        <title>{pageTitle}</title>
-        <meta property="og:title" content={pageTitle} />
+        <title>{title}</title>
+        <meta property="og:title" content={title} />
         <meta property="og:url" content={route} />
         <meta property="og:type" content="article" />
       </Helmet>
 
       <Header>
-        <h1
-          className={styles.title}
-          dangerouslySetInnerHTML={{
-            __html: title?.rendered,
-          }}
-        />
+        <h1 className={styles.title}>{title}</h1>
       </Header>
 
       <Content>
@@ -48,7 +43,7 @@ export default function Page({ page }) {
             <div
               className={styles.content}
               dangerouslySetInnerHTML={{
-                __html: content?.rendered,
+                __html: content,
               }}
             />
           </Container>
@@ -58,10 +53,16 @@ export default function Page({ page }) {
   );
 }
 
-export async function getStaticProps({ params = {} } = {}) {
+export async function getStaticProps({ params = {} } = {}, ...rest) {
+  const { pages } = await getAllPages();
+
+  const id = pages.find(({ slug }) => slug === params.slug)?.id;
+
+  const { page } = await getPageById(id);
+
   return {
     props: {
-      page: await getPageBySlug(params?.slug),
+      page,
     },
   };
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,10 +3,12 @@ import 'styles/globals.scss';
 import SiteContext from 'context/site-context';
 import { getSiteMetadata } from 'lib/site';
 import { getAllPosts } from 'lib/posts';
+import { getNavigationPages } from 'lib/pages';
 
-function App({ Component, pageProps, siteMetadata }) {
+function App({ Component, pageProps, metadata, navigation }) {
   const context = {
-    metadata: siteMetadata,
+    metadata,
+    navigation,
   };
   return (
     <SiteContext.Provider value={context}>
@@ -17,7 +19,8 @@ function App({ Component, pageProps, siteMetadata }) {
 
 App.getInitialProps = async function () {
   return {
-    siteMetadata: await getSiteMetadata(),
+    metadata: await getSiteMetadata(),
+    navigation: await getNavigationPages(),
   };
 };
 

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,14 +1,15 @@
-import 'styles/globals.scss';
-
 import { ApolloProvider } from '@apollo/client';
-import { useApollo } from 'lib/apolloClient';
+
 import SiteContext from 'context/site-context';
 import { getSiteMetadata } from 'lib/site';
 import { getAllPosts } from 'lib/posts';
 import { getNavigationPages } from 'lib/pages';
+import useApolloClient from 'hooks/use-apollo-client';
+
+import 'styles/globals.scss';
 
 function App({ Component, pageProps = {}, metadata, navigation }) {
-  const apolloClient = useApollo(pageProps.initialApolloState);
+  const apolloClient = useApolloClient(pageProps.initialApolloState);
 
   const context = {
     metadata,

--- a/src/pages/postlist.js
+++ b/src/pages/postlist.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { getPosts } from 'lib/posts';
-import { initializeApollo } from 'lib/apolloClient';
+import { initializeApollo } from 'lib/apollo-client';
 import useSite from 'hooks/use-site';
 
 import Layout from 'components/Layout';

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -80,7 +80,7 @@ export async function getStaticPaths() {
       },
     };
   });
-  console.log(paths);
+
   return {
     paths,
     fallback: false,

--- a/src/pages/postsql/[slug].js
+++ b/src/pages/postsql/[slug].js
@@ -2,7 +2,7 @@ import path from 'path';
 import { useRouter } from 'next/router';
 import { Helmet } from 'react-helmet';
 import { format } from 'date-fns';
-import { initializeApollo } from 'lib/apolloClient';
+import { initializeApollo } from 'lib/apollo-client';
 import { gql, useQuery, NetworkStatus } from '@apollo/client';
 import { getPostSlugs, getPostBySlug } from 'lib/postsql';
 

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,3 +1,5 @@
+@import "styles/settings/__settings";
+
 * {
   box-sizing: border-box;
 }
@@ -12,6 +14,14 @@ body {
 p {
   line-height: 1.6;
   margin: 1.2em 0;
+}
+
+ul {
+  padding-left: 1.2em;
+}
+
+a {
+  color: $color-primary;
 }
 
 img {

--- a/src/styles/pages/Post.module.scss
+++ b/src/styles/pages/Post.module.scss
@@ -1,36 +1,5 @@
 @import "styles/settings/__settings";
 
-.content {
-  font-size: 1.5rem;
-
-  h2,
-  h3,
-  h4,
-  p,
-  ul {
-    &:first-child {
-      margin-top: 0;
-    }
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  img {
-    display: block;
-    margin: 0 auto;
-  }
-}
-
-.metadata {
-  color: $color-gray-600;
-  list-style: none;
+.postMetadata {
   text-align: center;
-  padding: 0;
-  margin: 0;
-
-  li {
-    display: inline-block;
-  }
 }


### PR DESCRIPTION
This adds support for basic pages using the same method we're currently using for posts.

All top level pages are made available at the root, as in, slug `about` as a top level would be available at /about

This doesn't yet take into consideration child pages, which will be addressed as we start to build out the documentation

This also adds a mechanism for adding items to the navigation menu

It turns out that the API doesn't support grabbing the menu by default, which is a bummer, so I'm taking advantage of the "menu order" property, and if that's explicitly set (not 0), we include those as part of the navigation menu

This might be suited to flesh out more later, whether an add-on tutorial or something. There's a separate issue already open to explore menus