### PR TITLE
GraphQL POC

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
     "*": "yarn format:nopath"
   },
   "dependencies": {
+    "@apollo/client": "^3.2.2",
     "date-fns": "^2.16.1",
+    "dotenv": "^8.2.0",
     "fuse.js": "^6.4.1",
+    "graphql": "^15.3.0",
     "he": "^1.2.0",
     "loader-utils": "^2.0.0",
     "next": "9.5.2",

--- a/src/components/PostList/index.js
+++ b/src/components/PostList/index.js
@@ -1,0 +1,88 @@
+import { gql, useQuery, NetworkStatus } from '@apollo/client';
+import path from 'path';
+import useSite from 'hooks/use-site';
+import Link from 'next/link';
+export const ALL_POSTS_QUERY = gql`
+  query allPosts {
+    posts(first: 100) {
+      nodes {
+        title
+        uri
+        date
+        excerpt
+      }
+    }
+  }
+`;
+
+export default function PostList() {
+  const { homepage } = useSite();
+  const getRoute = (slug) => path.join(homepage, '/posts/', slug);
+
+  const { loading, error, data, fetchMore, networkStatus } = useQuery(ALL_POSTS_QUERY, {
+    // Setting this value to true will make the component rerender when
+    // the "networkStatus" changes, so we are able to know if it is fetching
+    // more data
+    notifyOnNetworkStatusChange: true,
+  });
+
+  if (error) return <div>Error loading posts.</div>;
+  if (loading) return <div>Loading</div>;
+
+  const {
+    posts: { nodes },
+  } = data;
+
+  return (
+    <section>
+      <ul>
+        {nodes.map((post, index) => (
+          <li key={`post.id-${index}`}>
+            <div>
+              <span>{index + 1}. </span>
+              <Link href={`/posts${post.uri}`}>{post.title}</Link>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <style jsx>{`
+        section {
+          padding-bottom: 20px;
+        }
+        li {
+          display: block;
+          margin-bottom: 10px;
+        }
+        div {
+          align-items: center;
+          display: flex;
+        }
+        a {
+          font-size: 14px;
+          margin-right: 10px;
+          text-decoration: none;
+          padding-bottom: 0;
+          border: 0;
+        }
+        span {
+          font-size: 14px;
+          margin-right: 5px;
+        }
+        ul {
+          margin: 0;
+          padding: 0;
+        }
+        button:before {
+          align-self: center;
+          border-style: solid;
+          border-width: 6px 4px 0 4px;
+          border-color: #ffffff transparent transparent transparent;
+          content: '';
+          height: 0;
+          margin-right: 5px;
+          width: 0;
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/src/components/PostList/index.js
+++ b/src/components/PostList/index.js
@@ -17,9 +17,8 @@ export const ALL_POSTS_QUERY = gql`
 
 export default function PostList() {
   const { homepage } = useSite();
-  const getRoute = (slug) => path.join(homepage, '/posts/', slug);
 
-  const { loading, error, data, fetchMore, networkStatus } = useQuery(ALL_POSTS_QUERY, {
+  const { loading, error, data, networkStatus } = useQuery(ALL_POSTS_QUERY, {
     // Setting this value to true will make the component rerender when
     // the "networkStatus" changes, so we are able to know if it is fetching
     // more data
@@ -40,7 +39,7 @@ export default function PostList() {
           <li key={`post.id-${index}`}>
             <div>
               <span>{index + 1}. </span>
-              <Link href={`/posts${post.uri}`}>{post.title}</Link>
+              <Link href={`/postsql${post.uri}`}>{post.title}</Link>
             </div>
           </li>
         ))}

--- a/src/lib/apolloClient.js
+++ b/src/lib/apolloClient.js
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
+import { concatPagination } from '@apollo/client/utilities';
+
+let apolloClient;
+
+function createApolloClient() {
+  return new ApolloClient({
+    ssrMode: typeof window === 'undefined',
+    link: new HttpLink({
+      uri: 'http://eggheaddnd.local/graphql', // Server URL (must be absolute)
+    }),
+    cache: new InMemoryCache({
+      typePolicies: {
+        Query: {
+          fields: {
+            allPosts: concatPagination(),
+          },
+        },
+      },
+    }),
+  });
+}
+
+export function initializeApollo(initialState = null) {
+  const _apolloClient = apolloClient ?? createApolloClient();
+
+  // If your page has Next.js data fetching methods that use Apollo Client, the initial state
+  // gets hydrated here
+  if (initialState) {
+    // Get existing cache, loaded during client side data fetching
+    const existingCache = _apolloClient.extract();
+    // Restore the cache using the data passed from getStaticProps/getServerSideProps
+    // combined with the existing cached data
+    _apolloClient.cache.restore({ ...existingCache, ...initialState });
+  }
+  // For SSG and SSR always create a new Apollo Client
+  if (typeof window === 'undefined') return _apolloClient;
+  // Create the Apollo Client once in the client
+  if (!apolloClient) apolloClient = _apolloClient;
+
+  return _apolloClient;
+}
+
+export function useApollo(initialState) {
+  const store = useMemo(() => initializeApollo(initialState), [initialState]);
+  return store;
+}

--- a/src/lib/postsql.js
+++ b/src/lib/postsql.js
@@ -1,0 +1,43 @@
+import { gql, useQuery, NetworkStatus } from '@apollo/client';
+import { initializeApollo } from 'lib/apolloClient';
+
+const GET_ALL_SLUGS = gql`
+  {
+    posts(first: 10000) {
+      edges {
+        node {
+          slug
+        }
+      }
+    }
+  }
+`;
+
+export async function getPostSlugs() {
+  const apolloClient = initializeApollo();
+
+  return await apolloClient.query({ query: GET_ALL_SLUGS });
+}
+
+const POST_BY_SLUG = (slug) => gql`
+query MyQuery {
+  postBy(slug: "${slug}"){
+    author {
+      node {
+        name
+      }
+    }
+    content
+    date
+    uri
+    title
+  }
+}
+`;
+
+export async function getPostBySlug(slug) {
+  console.log(slug);
+  const apolloClient = initializeApollo();
+  console.log('postbyslug', POST_BY_SLUG(slug));
+  return await apolloClient.query({ query: POST_BY_SLUG(slug) });
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,17 +1,22 @@
 import 'styles/globals.scss';
 
+import { ApolloProvider } from '@apollo/client';
+import { useApollo } from 'lib/apolloClient';
 import SiteContext from 'context/site-context';
 import { getSiteMetadata } from 'lib/site';
 import { getAllPosts } from 'lib/posts';
 
-function App({ Component, pageProps, siteMetadata }) {
+function App({ Component, pageProps = {}, siteMetadata }) {
+  const apolloClient = useApollo(pageProps.initialApolloState);
   const context = {
     metadata: siteMetadata,
   };
   return (
-    <SiteContext.Provider value={context}>
-      <Component {...pageProps} />
-    </SiteContext.Provider>
+    <ApolloProvider client={apolloClient}>
+      <SiteContext.Provider value={context}>
+        <Component {...pageProps} />
+      </SiteContext.Provider>
+    </ApolloProvider>
   );
 }
 

--- a/src/pages/postlist.js
+++ b/src/pages/postlist.js
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
+
+import { getPosts } from 'lib/posts';
+import { initializeApollo } from 'lib/apolloClient';
+import useSite from 'hooks/use-site';
+
+import Layout from 'components/Layout';
+import Header from 'components/Header';
+import Section from 'components/Section';
+import Container from 'components/Container';
+import PostCard from 'components/PostCard';
+import PostList, { ALL_POSTS_QUERY } from 'components/PostList';
+
+import styles from 'styles/pages/Home.module.scss';
+
+export default function Home({ posts }) {
+  const { metadata = {}, homepage } = useSite();
+  const { name, description } = metadata;
+
+  return (
+    <Layout>
+      <Header>
+        <h1
+          className={styles.title}
+          dangerouslySetInnerHTML={{
+            __html: name,
+          }}
+        />
+
+        <p
+          className={styles.description}
+          dangerouslySetInnerHTML={{
+            __html: description,
+          }}
+        />
+      </Header>
+
+      <Section>
+        <Container>
+          <PostList />
+        </Container>
+      </Section>
+    </Layout>
+  );
+}
+
+export async function getStaticProps() {
+  const apolloClient = initializeApollo();
+
+  await apolloClient.query({
+    query: ALL_POSTS_QUERY,
+  });
+
+  return {
+    props: {
+      initialApolloState: apolloClient.cache.extract(),
+    },
+    revalidate: 1,
+  };
+}

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -70,9 +70,10 @@ export async function getStaticPaths() {
   const routes = {};
 
   const { posts } = await getPosts();
-
+  console.log(posts);
   const paths = posts.map((post) => {
     const { slug } = post;
+    console.log(slug);
     return {
       params: {
         slug,

--- a/src/pages/postsql/[slug].js
+++ b/src/pages/postsql/[slug].js
@@ -2,8 +2,10 @@ import path from 'path';
 import { useRouter } from 'next/router';
 import { Helmet } from 'react-helmet';
 import { format } from 'date-fns';
+import { initializeApollo } from 'lib/apolloClient';
+import { gql, useQuery, NetworkStatus } from '@apollo/client';
+import { getPostSlugs, getPostBySlug } from 'lib/postsql';
 
-import { getPostBySlug, getPosts } from 'lib/posts';
 import useSite from 'hooks/use-site';
 
 import Layout from 'components/Layout';
@@ -18,27 +20,21 @@ export default function Post({ post }) {
   const { homepage } = useSite();
 
   const { slug } = router.query;
-  const { title, content, date } = post;
+  const { title, content, date } = post.data.postBy;
 
-  const pageTitle = title?.rendered;
   const route = path.join(homepage, '/posts/', slug);
 
   return (
     <Layout>
       <Helmet>
-        <title>{pageTitle}</title>
-        <meta property="og:title" content={pageTitle} />
+        <title>{title}</title>
+        <meta property="og:title" content={title} />
         <meta property="og:url" content={route} />
         <meta property="og:type" content="article" />
       </Helmet>
 
       <Header>
-        <h1
-          className={styles.title}
-          dangerouslySetInnerHTML={{
-            __html: title?.rendered,
-          }}
-        />
+        <h1>{title}</h1>
         <ul className={styles.metadata}>
           <time dateTime={date}>{format(new Date(date), 'PPP')}</time>
         </ul>
@@ -49,7 +45,7 @@ export default function Post({ post }) {
           <div
             className={styles.content}
             dangerouslySetInnerHTML={{
-              __html: content?.rendered,
+              __html: content,
             }}
           />
         </Container>
@@ -67,18 +63,16 @@ export async function getStaticProps({ params = {} } = {}) {
 }
 
 export async function getStaticPaths() {
-  const routes = {};
-
-  const { posts } = await getPosts();
-  const paths = posts.map((post) => {
-    const { slug } = post;
+  const response = await getPostSlugs();
+  const paths = response.data.posts.edges.map((post) => {
+    const { slug } = post.node;
     return {
       params: {
         slug,
       },
     };
   });
-  console.log(paths);
+
   return {
     paths,
     fallback: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,26 @@
   dependencies:
     cross-fetch "3.0.5"
 
+"@apollo/client@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.2.tgz#fe5cad4d53373979f13a925e9da02d8743e798a5"
+  integrity sha512-lw80L0i8PHhv863iLEwf5AvNak9STPNC6/0MWQYGZHV4yEryj7muLAueRzXkZHpoddGAou80xL8KqLAODNy0/A==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.5.2"
+    "@wry/equality" "^0.2.0"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.11.0"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.12.1"
+    prop-types "^15.7.2"
+    symbol-observable "^2.0.0"
+    terser "^5.2.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
 "@babel/code-frame@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -1026,6 +1046,11 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@graphql-typed-document-node/core@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
+  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+
 "@next/react-dev-overlay@9.5.2":
   version "9.5.2"
   resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-9.5.2.tgz#5d7878782e2819926b0dcd0f880c26ed527e9880"
@@ -1061,6 +1086,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/zen-observable@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.1.tgz#5668c0bce55a91f2b9566b1d8a4c0a8dbbc79764"
+  integrity sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -1206,6 +1236,20 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@wry/context@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.2.tgz#f2a5d5ab9227343aa74c81e06533c1ef84598ec7"
+  integrity sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==
+  dependencies:
+    tslib "^1.9.3"
+
+"@wry/equality@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.2.0.tgz#a312d1b6a682d0909904c2bcd355b02303104fb7"
+  integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
+  dependencies:
+    tslib "^1.9.3"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -2288,6 +2332,11 @@ domutils@^2.0.0:
     domelementtype "^2.0.1"
     domhandler "^3.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
@@ -2732,6 +2781,16 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.2
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+graphql-tag@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
+  integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
+
+graphql@^15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
+  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -2820,6 +2879,13 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 htmlparser2@4.1.0:
   version "4.1.0"
@@ -3819,6 +3885,13 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
+optimism@^0.12.1:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.12.2.tgz#de9dc3d2c914d7b34e08957a768967c0605beda9"
+  integrity sha512-k7hFhlmfLl6HNThIuuvYMQodC1c+q6Uc6V9cLVsMWyW514QuaxVJH/khPu2vLRIoDTpFdJ5sojlARhg1rzyGbg==
+  dependencies:
+    "@wry/context" "^0.5.2"
+
 os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
@@ -4260,7 +4333,7 @@ react-icons@^3.11.0:
   dependencies:
     camelcase "^5.0.0"
 
-react-is@16.13.1, react-is@^16.8.1:
+react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -4725,7 +4798,7 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@~0.5.12:
+source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -4743,7 +4816,7 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@0.7.3:
+source-map@0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -4949,6 +5022,11 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+symbol-observable@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
+  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -4977,6 +5055,15 @@ terser@4.8.0, terser@^4.1.2:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
+
+terser@^5.2.0:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.4.tgz#e510e05f86e0bd87f01835c3238839193f77a60c"
+  integrity sha512-dxuB8KQo8Gt6OVOeLg/rxfcxdNZI/V1G6ze1czFUzPeCFWZRtvZMgSzlZZ5OYBZ4HoG607F6pFPNLekJyV+yVw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 through2@^2.0.0:
   version "2.0.5"
@@ -5052,12 +5139,19 @@ traverse@0.6.6:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
+ts-invariant@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
+  integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
+  dependencies:
+    tslib "^1.9.3"
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
@@ -5359,3 +5453,8 @@ yaml@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
+
+zen-observable@^0.8.14:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
I haven't replaced the REST logic for now but have created complementary graphql equivalents.

To test:
- Make sure you have wpgraphql installed on your WP instance (https://www.wpgraphql.com/) - happy to support with this if necessary.
- Add a .env variable `GRAPHQL_URI=` (once you've set up WPGraphQL this will be WP_ROOT/graphql
- Start Next
- Navigate to /postlist
   - You should a list of all the posts on your WP instance
- Click on each of the posts
  - This should bring you to a properly rendered page for each post.