### PR TITLE
Fix uncategorized post bug

### DIFF
--- a/src/components/Metadata/Metadata.js
+++ b/src/components/Metadata/Metadata.js
@@ -43,7 +43,7 @@ const Metadata = ({ className, author, date, categories, options = DEFAULT_METAD
           </time>
         </li>
       )}
-      {Array.isArray(categories) && (
+      {Array.isArray(categories) && categories[0] && (
         <li className={styles.metadataCategories}>
           {compactCategories && (
             <p title={categories.map(({ name }) => name).join(', ')}>


### PR DESCRIPTION
### Description

If, for any reason, a post does not have a category associated, it breaks at Metadata component trying to get the slug.
It just adds a check if at least there is one category in order to mount the categories **list item** or not.

### Screenshots

|Error                    |
| ---------------------------------- |
| ![uncategorized-error](https://user-images.githubusercontent.com/50624358/95867140-35b3ab00-0d3f-11eb-8db2-dd850e74646b.png) |