### PR TITLE
Render title in Nav

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -101,7 +101,11 @@ const Nav = () => {
       <Section className={styles.navSection}>
         <p className={styles.navName}>
           <Link href="/">
-            <a>{title}</a>
+            <a
+              dangerouslySetInnerHTML={{
+                __html: title,
+              }}
+            />
           </Link>
         </p>
         <ul className={styles.navMenu}>


### PR DESCRIPTION
Looks like the title is coming back with an expectation of being rendered as HTML, so this renders the `<a>` element as such to show up right when the title has special characters

Fixes #40 