### PR TITLE
Fixes Issue #40

### DIFF
--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -17,5 +17,22 @@ export async function getSiteMetadata() {
 
   return {
     ...generalSettings,
+    title: decodeHtmlEntities(generalSettings.title),
   };
+}
+
+export function decodeHtmlEntities(text) {
+  if (typeof text !== 'string') {
+    throw new Error(`Failed to decode HTML entity: invalid type ${typeof src}`);
+  }
+
+  let decoded = text;
+
+  const entities = {
+    '&amp;': '\u0026',
+    '&quot;': '\u0022',
+    '&#039;': '\u0027',
+  };
+
+  return decoded.replace(/&amp;|&quot;|&#039;/g, (char) => entities[char]);
 }


### PR DESCRIPTION
### Description

When retrieving data from WordPress REST API is checked if the site title contains any HTML special character, and if is 
the case it replaces by its Unicode version. I found relevant to check: [ ' | " | & ], as it can appear in a site title. 

Reference: https://dev.w3.org/html5/html-author/charref

### Screenshots

|Before                   | After
| ---------------------------------- | ---------------------------------- |
| ![before](https://user-images.githubusercontent.com/50624358/95922381-894ae680-0d89-11eb-8169-3296f1b7fb88.png)| ![after](https://user-images.githubusercontent.com/50624358/95922393-8f40c780-0d89-11eb-8177-3f1500f3628e.png) |

Fixes #40 