### PR TITLE
Add Author page URL using name

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "loader-utils": "^2.0.0",
     "next": "9.5.5",
     "next-compose-plugins": "^2.2.0",
+    "parameterize": "^1.0.0",
     "path": "^0.12.7",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/src/components/Metadata/Metadata.js
+++ b/src/components/Metadata/Metadata.js
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
 import { categoryPathBySlug } from 'lib/categories';
-import { authorPathBySlug } from 'lib/users';
+import { authorPathByName } from 'lib/users';
 import { formatDate } from 'lib/datetime';
 import ClassName from 'models/classname';
 
@@ -30,7 +30,7 @@ const Metadata = ({ className, author, date, categories, options = DEFAULT_METAD
               alt="Author Avatar"
             />
             By{' '}
-            <Link href={authorPathBySlug(author.slug)}>
+            <Link href={authorPathByName(author.name)}>
               <a rel="author">{author.name}</a>
             </Link>
           </address>

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -1,5 +1,7 @@
 import { getApolloClient } from 'lib/apollo-client';
 
+import parameterize from 'parameterize';
+
 import { QUERY_ALL_USERS } from 'data/users';
 
 const ROLES_AUTHOR = ['author', 'administrator'];
@@ -24,6 +26,36 @@ export async function getUserBySlug(slug) {
   return {
     user,
   };
+}
+
+/**
+ * authorPathByName
+ */
+
+export function authorPathByName(name) {
+  return `/authors/${parameterize(name)}`;
+}
+
+/**
+ * getUserByNameSlug
+ */
+
+export async function getUserByNameSlug(name) {
+  const { users } = await getAllUsers();
+
+  const user = users.find((user) => parameterize(user.name) === name);
+
+  return {
+    user,
+  };
+}
+
+/**
+ * userSlugByName
+ */
+
+export function userSlugByName(name) {
+  return parameterize(name);
 }
 
 /**

--- a/src/pages/authors/[slug].js
+++ b/src/pages/authors/[slug].js
@@ -1,4 +1,4 @@
-import { getAllAuthors, getUserBySlug } from 'lib/users';
+import { getAllAuthors, getUserByNameSlug, userSlugByName } from 'lib/users';
 import { getPostsByAuthorSlug } from 'lib/posts';
 
 import TemplateArchive from 'templates/archive';
@@ -25,8 +25,8 @@ export default function Author({ user, posts }) {
 }
 
 export async function getStaticProps({ params = {} } = {}) {
-  const { user } = await getUserBySlug(params?.slug);
-  const { posts } = await getPostsByAuthorSlug(params?.slug);
+  const { user } = await getUserByNameSlug(params?.slug);
+  const { posts } = await getPostsByAuthorSlug(user?.slug);
   return {
     props: {
       user,
@@ -41,10 +41,10 @@ export async function getStaticPaths() {
   const { authors } = await getAllAuthors();
 
   const paths = authors.map((author) => {
-    const { slug } = author;
+    const { name } = author;
     return {
       params: {
-        slug,
+        slug: userSlugByName(name),
       },
     };
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4054,6 +4054,11 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
+parameterize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parameterize/-/parameterize-1.0.0.tgz#5c18639f16b0f58ed80390ccfcf1769c63d42264"
+  integrity sha512-7i+fCXWfdt7fEs9xMeQHC5e7G1OXX8J5JtfuzhgnqAZU1i6e2qX3aigQ2OH5uongdqmKz/xgMqfY7jtTZDTBYw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"


### PR DESCRIPTION
Fixes #35

### Description
It now creates author page using a parameterize version of the name (i.e. /authors/john-doe) instead of using the author slug coming from WP API. It adds two new functions at users lib, maintaining previous two functions (authorPathBySlug and getUserBySlug) , in case is needed in the future.