### PR TITLE
Improve Github Actions to respect yarn.lock

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,12 +4,23 @@ on: [push, pull_request]
 
 jobs:
   checks:
+    name: Linting
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
     steps:
+      # Checkout repo
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
         with:
-          node-version: 12
-      - run: npm install -g yarn
-      - run: yarn install
+          node-version: ${{ matrix.node-version }}
+
+      # install dependencies from yarn.lock
+      - name: Install dependencies with yarn
+        run: yarn install --frozen-lockfile
+
+      # Run linting with yarn
       - run: yarn lint


### PR DESCRIPTION
Currently, `yarn install` installs always the newest dependencies without respecting `yarn.lock`.
This makes build not easily reproducible and might trigger false positives errors in PRs.

Apart from that, reworked the Actions file a bit to remove unnecessary `npm install -g yarn` as well as testing for both NodeJS 12.x and 14.x