### PR TITLE
Search Index Compiler Run Check

### DIFF
--- a/plugins/search-index-compiler.js
+++ b/plugins/search-index-compiler.js
@@ -4,7 +4,6 @@ const he = require('he');
 const { promiseToWriteFile, mkdirp } = require('./util');
 
 const PLUGIN_NAME = 'SearchIndex';
-const INDEX_PAGE_COMPILATION_NAME = 'pages/index';
 const WORDPRESS_API_POSTS = '/wp-json/wp/v2/posts';
 
 class SearchIndexWebpackPlugin {

--- a/plugins/search-index.js
+++ b/plugins/search-index.js
@@ -11,6 +11,8 @@ module.exports = function indexSearch(nextConfig = {}) {
 
   return Object.assign({}, nextConfig, {
     webpack(config) {
+      // Ignore the search index in the filesystem to avoid a loop of changes
+
       if (config.watchOptions) {
         config.watchOptions.ignored.push(path.join('**', outputDirectory, outputName));
       }


### PR DESCRIPTION
I noticed when adding some logging to debug #37 that this plugin runs a billion times. This is an attempt to reduce it down to 1 time for production builds.

We're using the `run` and `watchRun` hooks again for webpack. The reason being I'm able to find an options object in both instances where I can check if we're on the `main` compilation and only run this process once when we see that

This is resulting in a single run for production build 🙌 

This still runs multiple times during development builds but I think that's okay. It'll run every time a change is made and recompiled.

I'm not sure if this actually fixes the issue related to #37, but I'm going to mark it as such and we can loop back if it pops back up as it should be much easier to debug with the logging i added and the fact it will only run once on build.

Fixes #37 