### PR TITLE
Fix final trailing slash breaking at WORDPRESS_HOST

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,5 @@
 const withPlugins = require('next-compose-plugins');
+const { removeLastTrailingSlash } = require('./plugins/util');
 
 const indexSearch = require('./plugins/search-index');
 
@@ -10,6 +11,6 @@ module.exports = withPlugins([[indexSearch]], {
   trailingSlash: true,
 
   env: {
-    WORDPRESS_HOST: process.env.WORDPRESS_HOST,
+    WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
   },
 });

--- a/plugins/util.js
+++ b/plugins/util.js
@@ -74,3 +74,9 @@ async function getAllPosts(host, process) {
 }
 
 module.exports.getAllPosts = getAllPosts;
+
+function removeLastTrailingSlash(url) {
+  return url.replace(/\/$/, '');
+}
+
+module.exports.removeLastTrailingSlash = removeLastTrailingSlash;

--- a/src/lib/apollo-client.js
+++ b/src/lib/apollo-client.js
@@ -1,9 +1,11 @@
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 import { concatPagination } from '@apollo/client/utilities';
 
+import { removeLastTrailingSlash } from 'lib/site';
+
 let apolloClient;
 
-const WORDPRESS_HOST = process.env.WORDPRESS_HOST;
+const WORDPRESS_HOST = removeLastTrailingSlash(process.env.WORDPRESS_HOST);
 
 /**
  * createApolloClient

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -51,3 +51,7 @@ export function decodeHtmlEntities(text) {
 
   return decoded.replace(/&amp;|&quot;|&#039;/g, (char) => entities[char]);
 }
+
+export function removeLastTrailingSlash(url) {
+  return url.replace(/\/$/, '');
+}


### PR DESCRIPTION
Fixes #83

### Description
It cleans last trailing slash at WORDPRESS_HOST env variable to not break graphql queries.