### PR TITLE
Add sitemap plugin and robots.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 
 public/wp-search.json
 public/feed.xml
+public/sitemap.xml
+public/robots.txt

--- a/next.config.js
+++ b/next.config.js
@@ -3,8 +3,9 @@ const { removeLastTrailingSlash } = require('./plugins/util');
 
 const indexSearch = require('./plugins/search-index');
 const feed = require('./plugins/feed');
+const sitemap = require('./plugins/sitemap');
 
-module.exports = withPlugins([[indexSearch], [feed]], {
+module.exports = withPlugins([[indexSearch], [feed], [sitemap]], {
   // By default, Next.js removes the trailing slash. One reason this would be good
   // to include is by default, the `path` property of the router for the homepage
   // is `/` and by using that, would instantly create a redirect

--- a/plugins/plugin-compiler.js
+++ b/plugins/plugin-compiler.js
@@ -25,6 +25,11 @@ class WebpackPlugin {
     const file = plugin.generate(data);
 
     await createFile(file, plugin.name, plugin.outputDirectory, plugin.outputLocation);
+
+    //If there is an aditional action to perform
+    if (!!plugin.postcreate) {
+      plugin.postcreate(plugin);
+    }
   }
 
   apply(compiler) {

--- a/plugins/sitemap.js
+++ b/plugins/sitemap.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const { getSitemapData, generateSitemap, generateRobotsTxt } = require('./util');
+
+const WebpackPlugin = require('./plugin-compiler');
+
+module.exports = function sitemap(nextConfig = {}) {
+  const { env, outputDirectory, outputName } = nextConfig;
+
+  const plugin = {
+    name: 'Sitemap',
+    outputDirectory: outputDirectory || './public',
+    outputName: outputName || 'sitemap.xml',
+    getData: getSitemapData,
+    generate: generateSitemap,
+    postcreate: generateRobotsTxt,
+  };
+
+  const { WORDPRESS_HOST } = env;
+
+  return Object.assign({}, nextConfig, {
+    webpack(config, options) {
+      if (config.watchOptions) {
+        config.watchOptions.ignored.push(path.join('**', plugin.outputDirectory, plugin.outputName));
+      }
+
+      config.plugins.push(
+        new WebpackPlugin({
+          host: WORDPRESS_HOST,
+          plugin,
+        })
+      );
+
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options);
+      }
+
+      return config;
+    },
+  });
+};


### PR DESCRIPTION
Fixes #27

### Description
It adds a sitemap generator plugin. Some considerations I made, open to be discuss:
- The plugin creates a sitemap with both **pages** (including homepage) and **posts**. I consider **not** to include **author** and **category** pages to avoid duplicate content.
- Pages (excluding homepage) are included with a lower priority than the posts, `0.3`. By default all urls have `0.5` of priority. 
- Is included an aditional function to generate a `robots.txt` file: By default is always generated. However, if someone passed in `outputDirectory` to nextConfig is checked if is a `public` subfolder in order to resolve sitemap URL. If the passed `outputDirectory` not correspond to a public subfolder then the robots.txt is not generated. (at _resolvePublicPathname()_ ).

> For example, if a user passes an `outputDirectory` like `./public/sitemap` to sitemap plugin, robots.txt will be written with the resolved absolute path: `https://next-wordpress-starter.netlify.app/sitemap/sitemap.xml`

Reference: https://www.sitemaps.org/protocol.html