### PR TITLE
Add JSON-LD support for all pages

### DIFF
--- a/src/lib/json-ld.js
+++ b/src/lib/json-ld.js
@@ -1,0 +1,138 @@
+import { Helmet } from 'react-helmet';
+
+import { authorPathByName } from 'lib/users';
+import { postPathBySlug } from 'lib/posts';
+import { pagePathBySlug } from 'lib/pages';
+
+import config from '../../package.json';
+
+export function ArticleJsonLd({ post = {}, siteTitle = '' }) {
+  const { homepage = '', faviconPath = '/favicon.ico' } = config;
+  const { title, slug, excerpt, date, author, categories, modified, featuredImage } = post;
+  const path = postPathBySlug(slug);
+  const datePublished = !!date && new Date(date);
+  const dateModified = !!modified && new Date(modified);
+
+  /** TODO - As image is a recommended field would be interesting to have a
+   * default image in case there is no featuredImage comming from WP,
+   * like the open graph social image
+   * */
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${homepage}${path}`,
+    },
+    headline: title,
+    image: [featuredImage?.sourceUrl],
+    datePublished: dateModified ? datePublished.toISOString() : '',
+    dateModified: dateModified ? dateModified.toISOString() : datePublished.toISOString(),
+    description: excerpt,
+    keywords: [categories.map(({ name }) => `${name}`).join(', ')],
+    copyrightYear: dateModified ? datePublished.getFullYear() : '',
+    author: {
+      '@type': 'Person',
+      name: author?.name,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: siteTitle,
+      logo: {
+        '@type': 'ImageObject',
+        url: `${homepage}${faviconPath}`,
+      },
+    },
+  };
+
+  return (
+    <Helmet encodeSpecialCharacters={false}>
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
+  );
+}
+
+export function WebsiteJsonLd({ siteTitle = '' }) {
+  const { homepage = '' } = config;
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: siteTitle,
+    url: homepage,
+    copyrightYear: new Date().getFullYear(),
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: `${homepage}/search/?q={search_term_string}`,
+      'query-input': 'required name=search_term_string',
+    },
+  };
+
+  return (
+    <Helmet encodeSpecialCharacters={false}>
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
+  );
+}
+
+export function WebpageJsonLd({ title = '', description = '', siteTitle = '', slug = '' }) {
+  const { homepage = '' } = config;
+  const path = pagePathBySlug(slug);
+
+  const jsonLd = {
+    '@context': 'http://schema.org',
+    '@type': 'WebPage',
+    name: title,
+    description: description,
+    url: `${homepage}${path}`,
+    publisher: {
+      '@type': 'ProfilePage',
+      name: siteTitle,
+    },
+  };
+
+  return (
+    <Helmet encodeSpecialCharacters={false}>
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
+  );
+}
+
+export function AuthorJsonLd({ author = {} }) {
+  const { homepage = '' } = config;
+  const { name, avatar, description } = author;
+  const path = authorPathByName(name);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: name,
+    image: avatar?.url,
+    url: `${homepage}${path}`,
+    description: description,
+  };
+
+  return (
+    <Helmet encodeSpecialCharacters={false}>
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
+  );
+}
+
+export function LogoJsonLd() {
+  const { homepage = '', faviconPath = '/favicon.ico' } = config;
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    url: `${homepage}`,
+    logo: `${homepage}${faviconPath}`,
+  };
+
+  return (
+    <Helmet encodeSpecialCharacters={false}>
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
+  );
+}

--- a/src/pages/[slug].js
+++ b/src/pages/[slug].js
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 import { format } from 'date-fns';
 
 import { getPageById, getAllPages } from 'lib/pages';
+import { WebpageJsonLd } from 'lib/json-ld';
 import useSite from 'hooks/use-site';
 
 import Layout from 'components/Layout';
@@ -18,7 +19,7 @@ export default function Page({ page }) {
   const { metadata = {} } = useSite();
   const { title: siteTitle } = metadata;
 
-  const { title, content, date, featuredImage } = page;
+  const { title, content, date, featuredImage, slug } = page;
 
   const pageTitle = title?.rendered;
 
@@ -33,6 +34,8 @@ export default function Page({ page }) {
         <meta property="og:description" content={metaDescription} />
         <meta property="og:type" content="article" />
       </Helmet>
+
+      <WebpageJsonLd title={title} description={metaDescription} siteTitle={siteTitle} slug={slug} />
 
       <Header>
         {featuredImage && (

--- a/src/pages/authors/[slug].js
+++ b/src/pages/authors/[slug].js
@@ -3,24 +3,29 @@ import { getPostsByAuthorSlug } from 'lib/posts';
 
 import TemplateArchive from 'templates/archive';
 import Title from 'components/Title';
+import { AuthorJsonLd } from 'lib/json-ld';
 
 import styles from 'styles/pages/Post.module.scss';
 
 export default function Author({ user, posts }) {
-  const { name, avatar, description } = user;
+  const { name, avatar, description, slug } = user;
 
   const postOptions = {
     excludeMetadata: ['author'],
   };
 
   return (
-    <TemplateArchive
-      title={name}
-      Title={<Title title={name} thumbnail={avatar} />}
-      description={description}
-      posts={posts}
-      postOptions={postOptions}
-    />
+    <>
+      <AuthorJsonLd author={user} />
+      <TemplateArchive
+        title={name}
+        Title={<Title title={name} thumbnail={avatar} />}
+        description={description}
+        posts={posts}
+        postOptions={postOptions}
+        slug={slug}
+      />
+    </>
   );
 }
 

--- a/src/pages/categories.js
+++ b/src/pages/categories.js
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet';
 
 import useSite from 'hooks/use-site';
 import { getAllCategories, categoryPathBySlug } from 'lib/categories';
+import { WebpageJsonLd } from 'lib/json-ld';
 
 import Layout from 'components/Layout';
 import Header from 'components/Header';
@@ -16,7 +17,8 @@ import styles from 'styles/pages/Categories.module.scss';
 export default function Categories({ categories }) {
   const { metadata = {} } = useSite();
   const { title: siteTitle } = metadata;
-
+  const title = 'Categories';
+  const slug = 'categories';
   let metaDescription = `Read ${categories.length} categories at ${siteTitle}.`;
 
   return (
@@ -24,9 +26,11 @@ export default function Categories({ categories }) {
       <Helmet>
         <title>Categories</title>
         <meta name="description" content={metaDescription} />
-        <meta property="og:title" content="Categories" />
+        <meta property="og:title" content={title} />
         <meta property="og:description" content={metaDescription} />
       </Helmet>
+
+      <WebpageJsonLd title={title} description={metaDescription} siteTitle={siteTitle} slug={slug} />
 
       <Header>
         <Container>

--- a/src/pages/categories/[slug].js
+++ b/src/pages/categories/[slug].js
@@ -8,9 +8,11 @@ import Title from 'components/Title';
 import styles from 'styles/pages/Post.module.scss';
 
 export default function Category({ category, posts }) {
-  const { name, description } = category;
+  const { name, description, slug } = category;
 
-  return <TemplateArchive title={name} Title={<Title title={name} />} description={description} posts={posts} />;
+  return (
+    <TemplateArchive title={name} Title={<Title title={name} />} description={description} posts={posts} slug={slug} />
+  );
 }
 
 export async function getStaticProps({ params = {} } = {}) {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { getAllPosts } from 'lib/posts';
+import { WebsiteJsonLd } from 'lib/json-ld';
 import useSite from 'hooks/use-site';
 
 import Layout from 'components/Layout';
@@ -18,6 +19,7 @@ export default function Home({ posts }) {
 
   return (
     <Layout>
+      <WebsiteJsonLd siteTitle={title} />
       <Header>
         <h1
           className={styles.title}

--- a/src/pages/posts.js
+++ b/src/pages/posts.js
@@ -5,7 +5,10 @@ import { getAllPosts } from 'lib/posts';
 import TemplateArchive from 'templates/archive';
 
 export default function Posts({ posts }) {
-  return <TemplateArchive title="All Posts" posts={posts} />;
+  const title = 'All Posts';
+  const slug = 'posts';
+
+  return <TemplateArchive title={title} posts={posts} slug={slug} />;
 }
 
 export async function getStaticProps({ params = {} } = {}) {

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet';
 
 import { getPostBySlug, getAllPosts } from 'lib/posts';
 import { formatDate } from 'lib/datetime';
+import { ArticleJsonLd } from 'lib/json-ld';
 import useSite from 'hooks/use-site';
 
 import Layout from 'components/Layout';
@@ -36,6 +37,8 @@ export default function Post({ post }) {
         <meta property="og:description" content={metaDescription} />
         <meta property="og:type" content="article" />
       </Helmet>
+
+      <ArticleJsonLd post={post} siteTitle={siteTitle} />
 
       <Header>
         {featuredImage && (

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -6,6 +6,8 @@ import TemplateArchive from 'templates/archive';
 
 export default function Search() {
   const { query, results, search } = useSearch();
+  const title = 'Search';
+  const slug = 'search';
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -14,5 +16,5 @@ export default function Search() {
     });
   }, []);
 
-  return <TemplateArchive title="Search" posts={results} />;
+  return <TemplateArchive title={title} posts={results} slug={slug} />;
 }

--- a/src/templates/archive.js
+++ b/src/templates/archive.js
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { getPosts } from 'lib/posts';
+import { WebpageJsonLd } from 'lib/json-ld';
 import useSite from 'hooks/use-site';
 
 import Layout from 'components/Layout';
@@ -23,6 +24,7 @@ export default function TemplateArchive({
   description,
   posts,
   postOptions = DEFAULT_POST_OPTIONS,
+  slug,
 }) {
   const { metadata = {} } = useSite();
   const { title: siteTitle } = metadata;
@@ -41,6 +43,8 @@ export default function TemplateArchive({
         <meta property="og:title" content={title} />
         <meta property="og:description" content={metaDescription} />
       </Helmet>
+
+      <WebpageJsonLd title={title} description={metaDescription} siteTitle={siteTitle} slug={slug} />
 
       <Header>
         <Container>


### PR DESCRIPTION
### Description

It creates JSON-LD support by adding the json-ld script to the React Helmet. There are 4 main structures:

1.- **ArticleJsonLd** - For blog posts
2.- **WebsiteJsonLd** - For index (with integrated searchbox)
3.- **AuthorJsonLd** - For authors page
4.- **WebpageJsonLd** - This is the most generic one. Is used in all the rest of pages.

I've checked results with different values at https://search.google.com/structured-data/testing-tool, and I believe is working fine.

For Article the image appears to be a recommended/important field and not every time a post has a _featuredImage_, so when #13 is solved would be great to include it as the default image for the post in case there is no _featureImage_.

Fixes #92