### PR TITLE
Flexible WPGraphQL Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npx create-next-app -e https://github.com/colbyfayock/next-wordpress-starter
 
 Add an `.env.local` file to the root with the following:
 ```
-WORDPRESS_HOST="http://wordpressite.com"
+WORDPRESS_GRAPHQL_ENDPOINT="http://wordpressite.com/graphql"
 ```
 
 ## 🚀 Getting Started
@@ -57,7 +57,7 @@ This project makes use of WPGraphQL to query WordPress with GraphQL. In order to
 Create a new file locally called `.env.local` and add the following:
 
 ```bash
-WORDPRESS_HOST="[host]"
+WORDPRESS_GRAPHQL_ENDPOINT="[WPGraphQL Endpoint]"
 ```
 
 Replace `[host]` with your the home URL of your WordPress instance.

--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,6 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap]], {
   trailingSlash: true,
 
   env: {
-    WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
+    WORDPRESS_GRAPHQL_ENDPOINT: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),
   },
 });

--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,7 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap]], {
   trailingSlash: true,
 
   env: {
+    WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
     WORDPRESS_GRAPHQL_ENDPOINT: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),
   },
 });

--- a/plugins/feed.js
+++ b/plugins/feed.js
@@ -14,7 +14,7 @@ module.exports = function feed(nextConfig = {}) {
     generate: generateFeed,
   };
 
-  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT, WORDPRESS_HOST } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -24,6 +24,7 @@ module.exports = function feed(nextConfig = {}) {
 
       config.plugins.push(
         new WebpackPluginCompiler({
+          host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
         })

--- a/plugins/feed.js
+++ b/plugins/feed.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { getFeedData, generateFeed } = require('./util');
 
-const WebpackPlugin = require('./plugin-compiler');
+const WebpackPluginCompiler = require('./plugin-compiler');
 
 module.exports = function feed(nextConfig = {}) {
   const { env, outputDirectory, outputName } = nextConfig;
@@ -14,7 +14,7 @@ module.exports = function feed(nextConfig = {}) {
     generate: generateFeed,
   };
 
-  const { WORDPRESS_HOST } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -23,8 +23,8 @@ module.exports = function feed(nextConfig = {}) {
       }
 
       config.plugins.push(
-        new WebpackPlugin({
-          host: WORDPRESS_HOST,
+        new WebpackPluginCompiler({
+          url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
         })
       );

--- a/plugins/plugin-compiler.js
+++ b/plugins/plugin-compiler.js
@@ -26,8 +26,8 @@ class WebpackPlugin {
         `[${plugin.name}] Failed to compile: invalid url and host type: url ${typeof url}; host ${typeof host}`
       );
     }
-
-    const apolloClient = createApolloClient(url);
+    console.log('endpoint', endpoint);
+    const apolloClient = createApolloClient(endpoint);
 
     const data = await plugin.getData(apolloClient, plugin.name);
 

--- a/plugins/plugin-compiler.js
+++ b/plugins/plugin-compiler.js
@@ -2,20 +2,29 @@ const path = require('path');
 
 const { createApolloClient, createFile } = require('./util');
 
+const DEFAULT_GRAPHQL_PATH = '/graphql';
+
 class WebpackPlugin {
   constructor(options = {}) {
     this.options = options;
   }
 
   async index(compilation, options) {
-    const { url, plugin } = options;
+    const { url, host, plugin } = options;
+    let endpoint = url;
+
+    if (!endpoint && host) {
+      endpoint = `${host}${DEFAULT_GRAPHQL_PATH}`;
+    }
 
     plugin.outputLocation = path.join(plugin.outputDirectory, plugin.outputName);
 
     console.log(`[${plugin.name}] Compiling file ${plugin.outputLocation}`);
 
-    if (typeof url !== 'string') {
-      throw new Error(`[${plugin.name}] Failed to compile: invalid url type ${typeof url}`);
+    if (typeof url !== 'string' && typeof host !== 'string') {
+      throw new Error(
+        `[${plugin.name}] Failed to compile: invalid url and host type: url ${typeof url}; host ${typeof host}`
+      );
     }
 
     const apolloClient = createApolloClient(url);

--- a/plugins/plugin-compiler.js
+++ b/plugins/plugin-compiler.js
@@ -21,12 +21,15 @@ class WebpackPlugin {
 
     console.log(`[${plugin.name}] Compiling file ${plugin.outputLocation}`);
 
-    if (typeof url !== 'string' && typeof host !== 'string') {
+    const hasUrl = typeof url === 'string';
+    const hasHost = typeof host === 'string';
+
+    if (!hasUrl && !hasHost) {
       throw new Error(
-        `[${plugin.name}] Failed to compile: invalid url and host type: url ${typeof url}; host ${typeof host}`
+        `[${plugin.name}] Failed to compile: Plase check that either WORDPRESS_GRAPHQL_ENDPOINT or WORDPRESS_HOST is set and configured properly.`
       );
     }
-    console.log('endpoint', endpoint);
+
     const apolloClient = createApolloClient(endpoint);
 
     const data = await plugin.getData(apolloClient, plugin.name);

--- a/plugins/plugin-compiler.js
+++ b/plugins/plugin-compiler.js
@@ -8,17 +8,17 @@ class WebpackPlugin {
   }
 
   async index(compilation, options) {
-    const { host, plugin } = options;
+    const { url, plugin } = options;
 
     plugin.outputLocation = path.join(plugin.outputDirectory, plugin.outputName);
 
     console.log(`[${plugin.name}] Compiling file ${plugin.outputLocation}`);
 
-    if (typeof host !== 'string') {
-      throw new Error(`[${plugin.name}] Failed to compile: invalid host type ${typeof host}`);
+    if (typeof url !== 'string') {
+      throw new Error(`[${plugin.name}] Failed to compile: invalid url type ${typeof url}`);
     }
 
-    const apolloClient = createApolloClient(host);
+    const apolloClient = createApolloClient(url);
 
     const data = await plugin.getData(apolloClient, plugin.name);
 

--- a/plugins/search-index.js
+++ b/plugins/search-index.js
@@ -14,7 +14,7 @@ module.exports = function indexSearch(nextConfig = {}) {
     generate: generateIndexSearch,
   };
 
-  const { WORDPRESS_HOST } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -24,7 +24,7 @@ module.exports = function indexSearch(nextConfig = {}) {
 
       config.plugins.push(
         new WebpackPlugin({
-          host: WORDPRESS_HOST,
+          url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
         })
       );

--- a/plugins/search-index.js
+++ b/plugins/search-index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { getAllPosts, generateIndexSearch } = require('./util');
 
-const WebpackPlugin = require('./plugin-compiler');
+const WebpackPluginCompiler = require('./plugin-compiler');
 
 module.exports = function indexSearch(nextConfig = {}) {
   const { env, outputDirectory, outputName } = nextConfig;
@@ -14,7 +14,7 @@ module.exports = function indexSearch(nextConfig = {}) {
     generate: generateIndexSearch,
   };
 
-  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT, WORDPRESS_HOST } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -23,7 +23,8 @@ module.exports = function indexSearch(nextConfig = {}) {
       }
 
       config.plugins.push(
-        new WebpackPlugin({
+        new WebpackPluginCompiler({
+          host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
         })

--- a/plugins/sitemap.js
+++ b/plugins/sitemap.js
@@ -15,7 +15,7 @@ module.exports = function sitemap(nextConfig = {}) {
     postcreate: generateRobotsTxt,
   };
 
-  const { WORDPRESS_HOST } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -25,7 +25,7 @@ module.exports = function sitemap(nextConfig = {}) {
 
       config.plugins.push(
         new WebpackPlugin({
-          host: WORDPRESS_HOST,
+          url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
         })
       );

--- a/plugins/sitemap.js
+++ b/plugins/sitemap.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { getSitemapData, generateSitemap, generateRobotsTxt } = require('./util');
 
-const WebpackPlugin = require('./plugin-compiler');
+const WebpackPluginCompiler = require('./plugin-compiler');
 
 module.exports = function sitemap(nextConfig = {}) {
   const { env, outputDirectory, outputName } = nextConfig;
@@ -15,7 +15,7 @@ module.exports = function sitemap(nextConfig = {}) {
     postcreate: generateRobotsTxt,
   };
 
-  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT, WORDPRESS_HOST } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -24,7 +24,8 @@ module.exports = function sitemap(nextConfig = {}) {
       }
 
       config.plugins.push(
-        new WebpackPlugin({
+        new WebpackPluginCompiler({
+          host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
         })

--- a/plugins/util.js
+++ b/plugins/util.js
@@ -59,9 +59,9 @@ function mkdirp(directory) {
  * createApolloClient
  */
 
-function createApolloClient(host) {
+function createApolloClient(url) {
   return new ApolloClient({
-    uri: `${host}/graphql`,
+    uri: url,
     cache: new InMemoryCache(),
   });
 }

--- a/plugins/util.js
+++ b/plugins/util.js
@@ -393,6 +393,7 @@ function resolvePublicPathname(outputDirectory, outputName) {
  */
 
 function removeLastTrailingSlash(url) {
+  if (typeof url !== 'string') return url;
   return url.replace(/\/$/, '');
 }
 

--- a/src/lib/apollo-client.js
+++ b/src/lib/apollo-client.js
@@ -5,7 +5,7 @@ import { removeLastTrailingSlash } from 'lib/site';
 
 let apolloClient;
 
-const WORDPRESS_HOST = removeLastTrailingSlash(process.env.WORDPRESS_HOST);
+const WORDPRESS_GRAPHQL_ENDPOINT = removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT);
 
 /**
  * createApolloClient
@@ -13,7 +13,7 @@ const WORDPRESS_HOST = removeLastTrailingSlash(process.env.WORDPRESS_HOST);
 
 export function _createApolloClient() {
   const link = new HttpLink({
-    uri: `${WORDPRESS_HOST}/graphql`,
+    uri: WORDPRESS_GRAPHQL_ENDPOINT,
   });
 
   const cache = new InMemoryCache({

--- a/src/lib/apollo-client.js
+++ b/src/lib/apollo-client.js
@@ -5,7 +5,11 @@ import { removeLastTrailingSlash } from 'lib/site';
 
 let apolloClient;
 
+const WORDPRESS_HOST = removeLastTrailingSlash(process.env.WORDPRESS_HOST);
 const WORDPRESS_GRAPHQL_ENDPOINT = removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT);
+
+const DEFAULT_GRAPHQL_PATH = '/graphql';
+const GRAPHQL_ENDPOINT = WORDPRESS_GRAPHQL_ENDPOINT || `${WORDPRESS_HOST}${DEFAULT_GRAPHQL_PATH}`;
 
 /**
  * createApolloClient
@@ -13,7 +17,7 @@ const WORDPRESS_GRAPHQL_ENDPOINT = removeLastTrailingSlash(process.env.WORDPRESS
 
 export function _createApolloClient() {
   const link = new HttpLink({
-    uri: WORDPRESS_GRAPHQL_ENDPOINT,
+    uri: GRAPHQL_ENDPOINT,
   });
 
   const cache = new InMemoryCache({

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -53,5 +53,6 @@ export function decodeHtmlEntities(text) {
 }
 
 export function removeLastTrailingSlash(url) {
+  if (typeof url !== 'string') return url;
   return url.replace(/\/$/, '');
 }


### PR DESCRIPTION
WPGraphQL supports changing the default /graphql, meaning, doing so would break the starter

I originally was going to add only support for that, but decided to allow just the wordpress_host for now, maybe we can revisit if that's not desired

This means, you can now either set `WORDPRESS_GRAPHQL_ENDPOINT` as the full endpoint or pass in `WORDPRESS_HOST` as you can today and either should work

Fixes #79