### PR TITLE
Add verbose option for plugins

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,8 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap]], {
 
   trailingSlash: true,
 
+  // By enabling verbose logging, it will provide additional output details for
+  // diagnostic purposes. By default is set to false.
   //verbose: true,
 
   env: {

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,8 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap]], {
 
   trailingSlash: true,
 
+  //verbose: true,
+
   env: {
     WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
     WORDPRESS_GRAPHQL_ENDPOINT: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),

--- a/plugins/feed.js
+++ b/plugins/feed.js
@@ -4,7 +4,7 @@ const { getFeedData, generateFeed } = require('./util');
 const WebpackPluginCompiler = require('./plugin-compiler');
 
 module.exports = function feed(nextConfig = {}) {
-  const { env, outputDirectory, outputName } = nextConfig;
+  const { env, outputDirectory, outputName, verbose = false } = nextConfig;
 
   const plugin = {
     name: 'Feed',
@@ -27,6 +27,7 @@ module.exports = function feed(nextConfig = {}) {
           host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
+          verbose,
         })
       );
 

--- a/plugins/search-index.js
+++ b/plugins/search-index.js
@@ -4,7 +4,7 @@ const { getAllPosts, generateIndexSearch } = require('./util');
 const WebpackPluginCompiler = require('./plugin-compiler');
 
 module.exports = function indexSearch(nextConfig = {}) {
-  const { env, outputDirectory, outputName } = nextConfig;
+  const { env, outputDirectory, outputName, verbose = false } = nextConfig;
 
   const plugin = {
     name: 'SearchIndex',
@@ -27,6 +27,7 @@ module.exports = function indexSearch(nextConfig = {}) {
           host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
+          verbose,
         })
       );
 

--- a/plugins/sitemap.js
+++ b/plugins/sitemap.js
@@ -4,7 +4,7 @@ const { getSitemapData, generateSitemap, generateRobotsTxt } = require('./util')
 const WebpackPluginCompiler = require('./plugin-compiler');
 
 module.exports = function sitemap(nextConfig = {}) {
-  const { env, outputDirectory, outputName } = nextConfig;
+  const { env, outputDirectory, outputName, verbose = false } = nextConfig;
 
   const plugin = {
     name: 'Sitemap',
@@ -28,6 +28,7 @@ module.exports = function sitemap(nextConfig = {}) {
           host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
+          verbose,
         })
       );
 

--- a/plugins/util.js
+++ b/plugins/util.js
@@ -10,15 +10,14 @@ const config = require('../package.json');
  * createFile
  */
 
-async function createFile(file, process, directory, location) {
+async function createFile(file, process, directory, location, verbose = false) {
   try {
     mkdirp(directory);
-    console.log(`[${process}] Created directory ${directory}`);
+    verbose && console.log(`[${process}] Created directory ${directory}`);
     await promiseToWriteFile(location, file);
-    console.log(`[${process}] Successfully wrote file to ${location}`);
+    verbose && console.log(`[${process}] Successfully wrote file to ${location}`);
   } catch (e) {
-    console.log(`[${process}] Failed to create file: ${e.message}`);
-    throw e;
+    throw new Error(`[${process}] Failed to create file: ${e.message}`);
   }
 }
 
@@ -70,7 +69,7 @@ function createApolloClient(url) {
  * getAllPosts
  */
 
-async function getAllPosts(apolloClient, process) {
+async function getAllPosts(apolloClient, process, verbose = false) {
   const query = gql`
     {
       posts(first: 10000) {
@@ -115,17 +114,15 @@ async function getAllPosts(apolloClient, process) {
       if (data.categories) {
         data.categories = data.categories.edges.map(({ node }) => node.name);
       }
-
       return data;
     });
 
-    console.log(`[${process}] Successfully fetched posts from ${apolloClient.link.options.uri}`);
-  } catch (e) {
-    console.log(`[${process}] Failed to fetch posts from ${apolloClient.link.options.uri}: ${e}`);
-  } finally {
+    verbose && console.log(`[${process}] Successfully fetched posts from ${apolloClient.link.options.uri}`);
     return {
       posts,
     };
+  } catch (e) {
+    throw new Error(`[${process}] Failed to fetch posts from ${apolloClient.link.options.uri}: ${e.message}`);
   }
 }
 
@@ -133,7 +130,7 @@ async function getAllPosts(apolloClient, process) {
  * getSiteMetadata
  */
 
-async function getSiteMetadata(apolloClient, process) {
+async function getSiteMetadata(apolloClient, process, verbose = false) {
   const query = gql`
     {
       generalSettings {
@@ -156,13 +153,12 @@ async function getSiteMetadata(apolloClient, process) {
       metadata.language = metadata.language.split('_')[0];
     }
 
-    console.log(`[${process}] Successfully fetched metadata from ${apolloClient.link.options.uri}`);
-  } catch (e) {
-    console.log(`[${process}] Failed to fetch metadata from ${apolloClient.link.options.uri}: ${e}`);
-  } finally {
+    verbose && console.log(`[${process}] Successfully fetched metadata from ${apolloClient.link.options.uri}`);
     return {
       metadata,
     };
+  } catch (e) {
+    throw new Error(`[${process}] Failed to fetch metadata from ${apolloClient.link.options.uri}: ${e.message}`);
   }
 }
 
@@ -170,7 +166,7 @@ async function getSiteMetadata(apolloClient, process) {
  * getSitePages
  */
 
-async function getPages(apolloClient, process) {
+async function getPages(apolloClient, process, verbose = false) {
   const query = gql`
     {
       pages(first: 10000) {
@@ -197,13 +193,12 @@ async function getPages(apolloClient, process) {
       }),
     ];
 
-    console.log(`[${process}] Successfully fetched page slugs from ${apolloClient.link.options.uri}`);
-  } catch (e) {
-    console.log(`[${process}] Failed to fetch page slugs from ${apolloClient.link.options.uri}: ${e}`);
-  } finally {
+    verbose && console.log(`[${process}] Successfully fetched page slugs from ${apolloClient.link.options.uri}`);
     return {
       pages,
     };
+  } catch (e) {
+    throw new Error(`[${process}] Failed to fetch page slugs from ${apolloClient.link.options.uri}: ${e.message}`);
   }
 }
 
@@ -211,9 +206,9 @@ async function getPages(apolloClient, process) {
  * getFeedData
  */
 
-async function getFeedData(apolloClient, process) {
-  const metadata = await getSiteMetadata(apolloClient, process);
-  const posts = await getAllPosts(apolloClient, process);
+async function getFeedData(apolloClient, process, verbose = false) {
+  const metadata = await getSiteMetadata(apolloClient, process, verbose);
+  const posts = await getAllPosts(apolloClient, process, verbose);
 
   return {
     ...metadata,
@@ -225,9 +220,9 @@ async function getFeedData(apolloClient, process) {
  * getFeedData
  */
 
-async function getSitemapData(apolloClient, process) {
-  const posts = await getAllPosts(apolloClient, process);
-  const pages = await getPages(apolloClient, process);
+async function getSitemapData(apolloClient, process, verbose = false) {
+  const posts = await getAllPosts(apolloClient, process, verbose);
+  const pages = await getPages(apolloClient, process, verbose);
 
   return {
     ...posts,
@@ -365,7 +360,7 @@ async function generateRobotsTxt({ outputDirectory, outputName }) {
     // Create robots.txt always at root directory
     await createFile(robots, 'Robots.txt', './public', './public/robots.txt');
   } catch (e) {
-    console.error(`[Robots.txt] Failed to create robots.txt: ${e.message}`);
+    throw new Error(`[Robots.txt] Failed to create robots.txt: ${e.message}`);
   }
 }
 
@@ -397,6 +392,25 @@ function removeLastTrailingSlash(url) {
   return url.replace(/\/$/, '');
 }
 
+/**
+ * terminalColor
+ */
+
+function terminalColor(text, level) {
+  switch (level) {
+    /** green */
+    case 'info':
+    default:
+      return `\x1b[32m${text}\x1b[0m`;
+    /** yellow */
+    case 'warn':
+      return `\x1b[33m${text}\x1b[0m`;
+    /** red */
+    case 'error':
+      return `\x1b[31m${text}\x1b[0m`;
+  }
+}
+
 module.exports = {
   createFile,
   promiseToWriteFile,
@@ -413,4 +427,5 @@ module.exports = {
   generateRobotsTxt,
   removeLastTrailingSlash,
   resolvePublicPathname,
+  terminalColor,
 };


### PR DESCRIPTION
### Description
Updates plugin message log: By default, without errors, one line per plugin will print reporting successful operation. It is possible to pass a boolean variable, `verbose`, at _next.config.js_ set to **true** to print previous informational messages.

Also errors are now handled regardless of message logging. Errors wont block the process as they are handled by try-catch.

One extra function is added to print colors at console, making easier to understand info messages from errors.

## Screenshots

|Info                    |Errors
| ---------------------------------- | ---------------------------------- |
| ![shot](https://user-images.githubusercontent.com/50624358/100639277-bb051600-3313-11eb-8873-e355ba274c81.png) | ![error](https://user-images.githubusercontent.com/50624358/100639296-c0faf700-3313-11eb-88b6-d13c96ee9cd3.png) |

Fix #100