### PR TITLE
Add related posts links to post page

### DIFF
--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -157,3 +157,23 @@ export function mapPostData(post = {}) {
 
   return data;
 }
+
+/**
+ * getRelatedPosts
+ */
+
+export async function getRelatedPosts(category, postId, count = 5) {
+  let relatedPosts = [];
+
+  if (!!category) {
+    const { posts } = await getPostsByCategoryId(category.categoryId);
+    const filtered = posts.filter(({ postId: id }) => id !== postId);
+    const sorted = sortObjectsByDate(filtered);
+    relatedPosts = sorted.map((post) => ({ title: post.title, slug: post.slug }));
+  }
+
+  if (relatedPosts.length > count) {
+    return relatedPosts.slice(0, count);
+  }
+  return relatedPosts;
+}

--- a/src/styles/pages/Post.module.scss
+++ b/src/styles/pages/Post.module.scss
@@ -12,4 +12,17 @@
 .postModified {
   color: $color-gray-500;
   font-style: italic;
+  margin-bottom: 3rem;
+}
+
+.relatedPosts {
+  display: flex;
+  flex-direction: column;
+  span {
+    font-size: 1.2em;
+    margin-bottom: 0.4em;
+  }
+  ul {
+    list-style: none;
+  }
 }


### PR DESCRIPTION
### Description

It adds at `Post` footer a list of related posts links (by post category). 
The default count of links is set to 5, but the function can receive a new count to show a custom number. The function filters the related posts to exclude the current post.

### Image
![related-posts](https://user-images.githubusercontent.com/50624358/106289415-052d4980-6228-11eb-8d01-408faa9b78ae.png)


Fixes #117