### PR TITLE
Add pagination component

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,10 +15,15 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap], [socialImages]],
 
   // By enabling verbose logging, it will provide additional output details for
   // diagnostic purposes. By default is set to false.
-  //verbose: true,
+  // verbose: true,
 
   env: {
     WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
     WORDPRESS_GRAPHQL_ENDPOINT: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),
+
+    // By default, the number of posts per page used in pagination is 10.
+    // This can be modified by setting the variable POSTS_PER_PAGE to a
+    // custom number.
+    // POSTS_PER_PAGE: 10,
   },
 });

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import Link from 'next/link';
+
+import config from '../../../package.json';
+import { Helmet } from 'react-helmet';
+
+import { GrPrevious as PreviousIcon, GrNext as NextIcon } from 'react-icons/gr';
+import styles from './Pagination.module.scss';
+
+const MAX_NUM_LINKS = 10;
+
+const { homepage = '' } = config;
+
+const Pagination = ({ pagesCount, currentPage, basePath }) => {
+  const path = `${basePath}/page/`;
+
+  const hasPreviousPage = pagesCount > 1 && currentPage > 1;
+  const hasNextPage = pagesCount > 1 && currentPage < pagesCount;
+
+  const pages = useMemo(() => {
+    let pages = [];
+    for (let i = 1; i < pagesCount + 1; i++) {
+      pages.push(i);
+    }
+    return pages;
+  }, [pagesCount]);
+
+  return (
+    <>
+      <Helmet>
+        {!hasPreviousPage && <link rel="canonical" href={`${homepage}${basePath}`} />}
+        {hasPreviousPage && <link rel="prev" href={`${homepage}${path}${currentPage - 1}`} />}
+        {hasNextPage && <link rel="next" href={`${homepage}${path}${currentPage + 1}`} />}
+      </Helmet>
+
+      <div className={styles.nav}>
+        {hasPreviousPage && (
+          <Link href={`${path}${currentPage - 1}`}>
+            <a className={styles.prev} aria-label="Previous Posts">
+              <PreviousIcon /> Previous
+            </a>
+          </Link>
+        )}
+
+        <ul className={styles.pages}>
+          {pages.map((page) => {
+            const active = page === currentPage;
+            return active ? (
+              <li key={page}>
+                <span className={styles.active}>{page}</span>
+              </li>
+            ) : (
+              <li key={page}>
+                <Link href={`${path}${page}`}>
+                  <a aria-label={`Page ${page}`}>
+                    <span>{page}</span>
+                  </a>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+
+        {hasNextPage && (
+          <Link href={`${path}${currentPage + 1}`}>
+            <a className={styles.next} aria-label="Next Posts">
+              Next <NextIcon />
+            </a>
+          </Link>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default Pagination;

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -1,13 +1,13 @@
-import { useMemo } from 'react';
 import Link from 'next/link';
 
 import config from '../../../package.json';
 import { Helmet } from 'react-helmet';
 
 import { GrPrevious as PreviousIcon, GrNext as NextIcon } from 'react-icons/gr';
+import { HiOutlineDotsHorizontal as Dots } from 'react-icons/hi';
 import styles from './Pagination.module.scss';
 
-const MAX_NUM_LINKS = 10;
+const MAX_NUM_PAGES = 9;
 
 const { homepage = '' } = config;
 
@@ -17,9 +17,33 @@ const Pagination = ({ pagesCount, currentPage, basePath }) => {
   const hasPreviousPage = pagesCount > 1 && currentPage > 1;
   const hasNextPage = pagesCount > 1 && currentPage < pagesCount;
 
-  const pages = useMemo(() => {
-    return [...new Array(pagesCount)].map((_, i) => i + 1);
-  }, [pagesCount]);
+  let hasPrevDots = false;
+  let hasNextDots = false;
+
+  function getPages() {
+    let pages = pagesCount;
+    let start = 0;
+    // If the number of pages exceeds the max
+    if (pagesCount > MAX_NUM_PAGES) {
+      // Set number of pages to the max
+      pages = MAX_NUM_PAGES;
+      const half = Math.ceil(MAX_NUM_PAGES / 2);
+      const isHead = currentPage <= half;
+      const isTail = currentPage > pagesCount - half;
+      hasNextDots = !isTail;
+      // If the current page is at the head, the start variable remains 0
+      if (!isHead) {
+        hasPrevDots = true;
+        // If the current page is at the tail, the start variable is set to
+        // the last chunk. Otherwise the start variable will place the current
+        // page at the middle
+        start = isTail ? pagesCount - MAX_NUM_PAGES : currentPage - half;
+      }
+    }
+    return [...new Array(pages)].map((_, i) => i + 1 + start);
+  }
+
+  const pages = getPages();
 
   return (
     <>
@@ -39,6 +63,11 @@ const Pagination = ({ pagesCount, currentPage, basePath }) => {
         )}
 
         <ul className={styles.pages}>
+          {hasPrevDots && (
+            <li className={styles.dots}>
+              <Dots aria-label={`Navigation to pages 1-${pages[0] - 1} hidden`} />
+            </li>
+          )}
           {pages.map((page) => {
             const active = page === currentPage;
             return active ? (
@@ -57,6 +86,11 @@ const Pagination = ({ pagesCount, currentPage, basePath }) => {
               </li>
             );
           })}
+          {hasNextDots && (
+            <li className={styles.dots}>
+              <Dots aria-label={`Navigation to pages ${pages[pages.length - 1] + 1}-${pagesCount} hidden`} />
+            </li>
+          )}
         </ul>
 
         {hasNextPage && (

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -18,11 +18,7 @@ const Pagination = ({ pagesCount, currentPage, basePath }) => {
   const hasNextPage = pagesCount > 1 && currentPage < pagesCount;
 
   const pages = useMemo(() => {
-    let pages = [];
-    for (let i = 1; i < pagesCount + 1; i++) {
-      pages.push(i);
-    }
-    return pages;
+    return [...new Array(pagesCount)].map((_, i) => i + 1);
   }, [pagesCount]);
 
   return (
@@ -33,10 +29,10 @@ const Pagination = ({ pagesCount, currentPage, basePath }) => {
         {hasNextPage && <link rel="next" href={`${homepage}${path}${currentPage + 1}`} />}
       </Helmet>
 
-      <div className={styles.nav}>
+      <nav className={styles.nav} role="navigation" aria-label="Pagination Navigation">
         {hasPreviousPage && (
           <Link href={`${path}${currentPage - 1}`}>
-            <a className={styles.prev} aria-label="Previous Posts">
+            <a className={styles.prev} aria-label="Goto Previous Page">
               <PreviousIcon /> Previous
             </a>
           </Link>
@@ -47,12 +43,14 @@ const Pagination = ({ pagesCount, currentPage, basePath }) => {
             const active = page === currentPage;
             return active ? (
               <li key={page}>
-                <span className={styles.active}>{page}</span>
+                <span className={styles.active} aria-label={`Current Page, Page ${page}`} aria-current="true">
+                  {page}
+                </span>
               </li>
             ) : (
               <li key={page}>
                 <Link href={`${path}${page}`}>
-                  <a aria-label={`Page ${page}`}>
+                  <a aria-label={`Goto Page ${page}`}>
                     <span>{page}</span>
                   </a>
                 </Link>
@@ -63,12 +61,12 @@ const Pagination = ({ pagesCount, currentPage, basePath }) => {
 
         {hasNextPage && (
           <Link href={`${path}${currentPage + 1}`}>
-            <a className={styles.next} aria-label="Next Posts">
+            <a className={styles.next} aria-label="Goto Next Page">
               Next <NextIcon />
             </a>
           </Link>
         )}
-      </div>
+      </nav>
     </>
   );
 };

--- a/src/components/Pagination/Pagination.module.scss
+++ b/src/components/Pagination/Pagination.module.scss
@@ -25,6 +25,9 @@
       color: $color-primary;
       background-color: $color-gray-50;
     }
+    svg {
+      width: 0.8rem;
+    }
   }
 
   ul {

--- a/src/components/Pagination/Pagination.module.scss
+++ b/src/components/Pagination/Pagination.module.scss
@@ -52,3 +52,9 @@
 .prev {
   margin-right: auto;
 }
+
+.dots {
+  display: flex;
+  align-self: flex-end;
+  margin: 0 0.2rem -0.2rem 0.2rem;
+}

--- a/src/components/Pagination/Pagination.module.scss
+++ b/src/components/Pagination/Pagination.module.scss
@@ -1,0 +1,51 @@
+@import "styles/settings/__settings";
+
+.nav {
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6em;
+
+  > * {
+    display: flex;
+    gap: 0.3em;
+    align-items: center;
+    justify-content: center;
+    font-size: 1em;
+  }
+
+  a {
+    color: $color-gray-800;
+    text-decoration: none;
+    cursor: pointer;
+    border: 1px solid $color-gray-200;
+    border-radius: 0.4em;
+    padding: 0.2em 0.8em;
+    &:hover {
+      color: $color-primary;
+      background-color: $color-gray-50;
+    }
+  }
+
+  ul {
+    list-style-type: none;
+  }
+}
+
+.active {
+  font-weight: 600;
+  padding: 0.2em 0.8em;
+}
+
+.pages {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  @media (max-width: 768px) {
+    display: none;
+  }
+}
+.prev {
+  margin-right: auto;
+}

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -1,0 +1,1 @@
+export { default } from './Pagination';

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -177,3 +177,52 @@ export async function getRelatedPosts(category, postId, count = 5) {
   }
   return relatedPosts;
 }
+
+/**
+ * sortStickyPosts
+ */
+
+export function sortStickyPosts(posts) {
+  return [...posts].sort((post) => (post.isSticky ? -1 : 1));
+}
+
+/**
+ * getPostsPerPage
+ */
+
+export function getPostsPerPage() {
+  // If POST_PER_PAGE is not defined, is set to 10 by default
+  return Number(process.env.POSTS_PER_PAGE) || 10;
+}
+
+/**
+ * getPageCount
+ */
+
+export function getPagesCount(posts) {
+  const postsPerPage = getPostsPerPage();
+  return Math.ceil(posts.length / postsPerPage);
+}
+
+/**
+ * getPaginatedPosts
+ */
+
+export async function getPaginatedPosts(currentPage = 1) {
+  const { posts } = await getAllPosts();
+  const postsPerPage = getPostsPerPage();
+  const pagesCount = getPagesCount(posts);
+  let page = Number(currentPage);
+  if (typeof page === 'undefined' || isNaN(page) || page > pagesCount) {
+    page = 1;
+  }
+  const offset = postsPerPage * (page - 1);
+  const sortedPosts = sortStickyPosts(posts);
+  return {
+    posts: sortedPosts.slice(offset, offset + postsPerPage),
+    pagination: {
+      currentPage: page,
+      pagesCount,
+    },
+  };
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 
-import { getAllPosts } from 'lib/posts';
+import { getAllPosts, sortStickyPosts } from 'lib/posts';
 import { WebsiteJsonLd } from 'lib/json-ld';
 import useSite from 'hooks/use-site';
 
@@ -58,7 +58,7 @@ export async function getStaticProps() {
   const { posts } = await getAllPosts();
   return {
     props: {
-      posts: posts.sort((post) => (post.isSticky ? -1 : 1)),
+      posts: sortStickyPosts(posts),
     },
   };
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,19 +1,17 @@
-import { useEffect } from 'react';
-import { Helmet } from 'react-helmet';
-
-import { getAllPosts, sortStickyPosts } from 'lib/posts';
-import { WebsiteJsonLd } from 'lib/json-ld';
 import useSite from 'hooks/use-site';
+import { getPaginatedPosts } from 'lib/posts';
+import { WebsiteJsonLd } from 'lib/json-ld';
 
 import Layout from 'components/Layout';
 import Header from 'components/Header';
 import Section from 'components/Section';
 import Container from 'components/Container';
 import PostCard from 'components/PostCard';
+import Pagination from 'components/Pagination';
 
 import styles from 'styles/pages/Home.module.scss';
 
-export default function Home({ posts }) {
+export default function Home({ posts, pagination }) {
   const { metadata = {} } = useSite();
   const { title, description } = metadata;
 
@@ -48,6 +46,13 @@ export default function Home({ posts }) {
               );
             })}
           </ul>
+          {pagination && (
+            <Pagination
+              currentPage={pagination?.currentPage}
+              pagesCount={pagination?.pagesCount}
+              basePath={pagination?.basePath}
+            />
+          )}
         </Container>
       </Section>
     </Layout>
@@ -55,10 +60,14 @@ export default function Home({ posts }) {
 }
 
 export async function getStaticProps() {
-  const { posts } = await getAllPosts();
+  const { posts, pagination } = await getPaginatedPosts();
   return {
     props: {
-      posts: sortStickyPosts(posts),
+      posts,
+      pagination: {
+        ...pagination,
+        basePath: '/posts',
+      },
     },
   };
 }

--- a/src/pages/posts/page/[page].js
+++ b/src/pages/posts/page/[page].js
@@ -1,6 +1,4 @@
-import { useEffect } from 'react';
-
-import { getPaginatedPosts } from 'lib/posts';
+import { getAllPosts, getPagesCount, getPaginatedPosts } from 'lib/posts';
 
 import TemplateArchive from 'templates/archive';
 
@@ -12,7 +10,7 @@ export default function Posts({ posts, pagination }) {
 }
 
 export async function getStaticProps({ params = {} } = {}) {
-  const { posts, pagination } = await getPaginatedPosts();
+  const { posts, pagination } = await getPaginatedPosts(params?.page);
   return {
     props: {
       posts,
@@ -21,5 +19,17 @@ export async function getStaticProps({ params = {} } = {}) {
         basePath: '/posts',
       },
     },
+  };
+}
+
+export async function getStaticPaths() {
+  const { posts } = await getAllPosts();
+  const pagesCount = getPagesCount(posts);
+  const paths = [...new Array(pagesCount)].map((_, i) => {
+    return { params: { page: String(i + 1) } };
+  });
+  return {
+    paths,
+    fallback: false,
   };
 }

--- a/src/templates/archive.js
+++ b/src/templates/archive.js
@@ -15,6 +15,7 @@ import PostCard from 'components/PostCard';
 import searchIndex from 'public/wp-search.json';
 
 import styles from 'styles/templates/Archive.module.scss';
+import Pagination from '../components/Pagination/Pagination';
 
 const DEFAULT_POST_OPTIONS = {};
 
@@ -25,6 +26,7 @@ export default function TemplateArchive({
   posts,
   postOptions = DEFAULT_POST_OPTIONS,
   slug,
+  pagination,
 }) {
   const { metadata = {} } = useSite();
   const { title: siteTitle } = metadata;
@@ -72,6 +74,13 @@ export default function TemplateArchive({
               );
             })}
           </ul>
+          {pagination && (
+            <Pagination
+              currentPage={pagination?.currentPage}
+              pagesCount={pagination?.pagesCount}
+              basePath={pagination?.basePath}
+            />
+          )}
         </Container>
       </Section>
     </Layout>


### PR DESCRIPTION
### Description
The variable `POSTS_PER_PAGE` at _next.config.js_ controls the number of posts render at each page. The component has been added to `template/archive` and is being used at `posts/` and `posts/page/[page]`.  The dynamic paths are created at [page].js. 

From SEO perspective, it is used rel="next" and rel="prev" (conditionally) and for the first page the canonical link to posts/ (because `posts/page/1` and `posts/` will have duplicated content).

There is one aditional function `sortStickyPosts` to make the code reusable and converting it into a pure function avoiding possible side effects.

### UI
I thought that for smaller screens or mobile devices (under 768px) would be a good idea to hide the page links and leave only the next/prev links. Totally open for any feedback/changes here.

|Dektop                    |Mobile
| ---------------------------------- | ---------------------------------- |
| ![pagination](https://user-images.githubusercontent.com/50624358/108891184-2dbd1f00-75ed-11eb-90f6-49fef6af8516.png)| ![pagination-mobile](https://user-images.githubusercontent.com/50624358/108891199-344b9680-75ed-11eb-8e10-1d0303e7ee6d.png) |

### To be done
There is a case not contemplated: having a big quantity of pages. For the next iteration would be good idea to have something that handles this, like: [1] [2] [3] [...] [20] [21],  shortening the number of links in case there are a lot. 
I though to send this PR first, to validate that the approach and the implementation is correct before going into that case.

Fixes #9 