### PR TITLE
Add a custom 404 page

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { Helmet } from 'react-helmet';
+
+import Layout from 'components/Layout';
+import Section from 'components/Section';
+import Container from 'components/Container';
+
+import styles from 'styles/pages/404.module.scss';
+
+export default function Custom404() {
+  return (
+    <Layout>
+      <Helmet>
+        <title>404 | Page not found</title>
+        <meta name="robots" content="noindex, nofollow" />
+      </Helmet>
+      <Section>
+        <Container className={styles.center}>
+          <h1>Page Not Found</h1>
+          <span>The page you were looking for could not be found.</span>
+          <p>
+            <Link href="/">
+              <a>Go back home</a>
+            </Link>
+          </p>
+        </Container>
+      </Section>
+    </Layout>
+  );
+}

--- a/src/styles/pages/404.module.scss
+++ b/src/styles/pages/404.module.scss
@@ -1,0 +1,7 @@
+@import "styles/settings/__settings";
+
+.center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}


### PR DESCRIPTION
### Description
It adds a custom 404 page, wrapped inside the Layout component with a homepage link. 

![custom-404](https://user-images.githubusercontent.com/50624358/109076167-ed3acf80-76d8-11eb-9f7a-1d00e1142c33.png)

#Fixes #133