### PR TITLE
Fix excerpt field at RSS feed

### DIFF
--- a/plugins/util.js
+++ b/plugins/util.js
@@ -76,6 +76,7 @@ async function getAllPosts(apolloClient, process, verbose = false) {
         edges {
           node {
             title
+            excerpt
             postId
             slug
             date
@@ -114,6 +115,13 @@ async function getAllPosts(apolloClient, process, verbose = false) {
       if (data.categories) {
         data.categories = data.categories.edges.map(({ node }) => node.name);
       }
+
+      if (data.excerpt) {
+        //Sanitize the excerpt by removing all HTML tags
+        const regExHtmlTags = /(<([^>]+)>)/g;
+        data.excerpt = data.excerpt.replace(regExHtmlTags, '');
+      }
+
       return data;
     });
 


### PR DESCRIPTION
## Description 
It fixes the query at `getAllPosts()` by adding the excerpt field, so the RSS feed can be created correctly with description. 

As the excerpt content comes with HTML tags, it was necessary to sanitize it. One possible way to solve it is to use `excerpt(format: RAW)` at the GraphQL query, but seems like this option is only [available for an authenticated user](https://stackoverflow.com/questions/61106355/problem-with-getting-raw-format-of-excerpt-in-wpgraphql-using-apollo) and it would add some extra complexity. So the simplest way I found is to use a regex to remove the tags.

Fixes #125