### PR TITLE
Dynamic Navigation Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ WORDPRESS_GRAPHQL_ENDPOINT="[WPGraphQL Endpoint]"
 
 Replace the contents of the variable with your WPGraphQL endpoint. By default, it should resemble `[Your Host]/graphql`.
 
+*Note: environment variables can optionally be statically configured in next.config.js*
+
 #### All Environment Variables
 
-| Name                       | Required | Description                                   |
-| -------------------------- | -------- | --------------------------------------------- |
-| WORDPRESS_GRAPHQL_ENDPOINT | Yes      | Unique API key from your Applitools account   |
-| WORDPRESS_PLUGIN_SEO       | No       | Enables SEO plugin support (true, false)      |
+| Name                               | Required | Default | Description                                   |
+| ---------------------------------- | -------- | -       | --------------------------------------------- |
+| WORDPRESS_GRAPHQL_ENDPOINT         | Yes      | -       | Unique API key from your Applitools account   |
+| WORDPRESS_MENU_LOCATION_NAVIGATION | No       | PRIMARY | Configures header navigation Menu Location    |
+| WORDPRESS_PLUGIN_SEO               | No       | false   | Enables SEO plugin support (true, false)      |
 
 ### Development
 

--- a/next.config.js
+++ b/next.config.js
@@ -18,10 +18,13 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap], [socialImages]],
   // verbose: true,
 
   env: {
-    MENU_LOCATION_NAVIGATION: 'PRIMARY',
-    WORDPRESS_PLUGIN_SEO: parseEnvValue(process.env.WORDPRESS_PLUGIN_SEO, false),
-    WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
     WORDPRESS_GRAPHQL_ENDPOINT: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),
+    WORDPRESS_MENU_LOCATION_NAVIGATION: process.env.WORDPRESS_MENU_LOCATION_NAVIGATION || 'PRIMARY',
+    WORDPRESS_PLUGIN_SEO: parseEnvValue(process.env.WORDPRESS_PLUGIN_SEO, false),
+
+    // TODO: remove and throw warning if used instead of WORDPRESS_GRAPHQL_ENDPOINT
+
+    WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
 
     // By default, the number of posts per page used in pagination is 10.
     // This can be modified by setting the variable POSTS_PER_PAGE to a

--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,7 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap], [socialImages]],
   // verbose: true,
 
   env: {
+    MENU_LOCATION_NAVIGATION: 'PRIMARY',
     WORDPRESS_PLUGIN_SEO: parseEnvValue(process.env.WORDPRESS_PLUGIN_SEO, false),
     WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
     WORDPRESS_GRAPHQL_ENDPOINT: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -24,7 +24,7 @@ const Nav = () => {
   const { title } = metadata;
 
   const navigation = findMenuByLocation(menus, [
-    process.env.MENU_LOCATION_NAVIGATION,
+    process.env.WORDPRESS_MENU_LOCATION_NAVIGATION,
     MENU_LOCATION_NAVIGATION_DEFAULT,
   ]);
 

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -6,6 +6,7 @@ import useSite from 'hooks/use-site';
 import useSearch from 'hooks/use-search';
 import { postPathBySlug } from 'lib/posts';
 import { pagePathBySlug } from 'lib/pages';
+import { findMenuByLocation, MENU_LOCATION_NAVIGATION_DEFAULT } from 'lib/menus';
 
 import Section from 'components/Section';
 
@@ -19,8 +20,13 @@ const Nav = () => {
 
   const [searchVisibility, setSearchVisibility] = useState(SEARCH_HIDDEN);
 
-  const { metadata = {}, navigation } = useSite();
+  const { metadata = {}, menus } = useSite();
   const { title } = metadata;
+
+  const navigation = findMenuByLocation(menus, [
+    process.env.MENU_LOCATION_NAVIGATION,
+    MENU_LOCATION_NAVIGATION_DEFAULT,
+  ]);
 
   const { query, results, search, clearSearch } = useSearch({
     maxResults: 5,
@@ -174,12 +180,19 @@ const Nav = () => {
           </Link>
         </p>
         <ul className={styles.navMenu}>
-          {navigation.map(({ slug, title = {} }) => {
+          {navigation?.menuItems.map(({ id, path, label, title, target }) => {
             return (
-              <li key={slug}>
-                <Link href={pagePathBySlug(slug)}>
-                  <a>{title}</a>
-                </Link>
+              <li key={id}>
+                {!path.includes('http') && !target && (
+                  <Link href={path}>
+                    <a title={title}>{label}</a>
+                  </Link>
+                )}
+                {path.includes('http') && (
+                  <a href={path} title={title} target={target}>
+                    {label}
+                  </a>
+                )}
               </li>
             );
           })}

--- a/src/data/menus.js
+++ b/src/data/menus.js
@@ -1,0 +1,29 @@
+import { gql } from '@apollo/client';
+
+export const QUERY_ALL_MENUS = gql`
+  {
+    menus {
+      edges {
+        node {
+          id
+          menuId
+          menuItems {
+            edges {
+              node {
+                cssClasses
+                id
+                label
+                title
+                target
+                path
+              }
+            }
+          }
+          name
+          slug
+          locations
+        }
+      }
+    }
+  }
+`;

--- a/src/lib/menus.js
+++ b/src/lib/menus.js
@@ -1,0 +1,81 @@
+import { getApolloClient } from 'lib/apollo-client';
+
+import { QUERY_ALL_MENUS } from 'data/menus';
+
+export const MENU_LOCATION_NAVIGATION_DEFAULT = 'DEFAULT_NAVIGATION';
+
+/**
+ * getAllMenus
+ */
+
+export async function getAllMenus(options) {
+  const apolloClient = getApolloClient();
+
+  const data = await apolloClient.query({
+    query: QUERY_ALL_MENUS,
+  });
+
+  const menus = data?.data.menus.edges.map(mapMenuData);
+
+  return {
+    menus,
+  };
+}
+
+/**
+ * mapMenuData
+ */
+
+export function mapMenuData(menu = {}) {
+  const { node } = menu;
+  const data = { ...node };
+
+  data.menuItems = data.menuItems.edges.map(({ node }) => {
+    return { ...node };
+  });
+
+  return data;
+}
+
+/**
+ * mapPagesToMenuItems
+ */
+
+export function mapPagesToMenuItems(pages) {
+  return pages.map(({ id, uri, title }) => {
+    return {
+      label: title,
+      path: uri,
+      id,
+    };
+  });
+}
+
+/**
+ * createMenuFromPages
+ */
+
+export function createMenuFromPages({ locations, pages }) {
+  return {
+    menuItems: mapPagesToMenuItems(pages),
+    locations,
+  };
+}
+
+/**
+ * findMenuByLocation
+ */
+
+export function findMenuByLocation(menus, location) {
+  let menu;
+
+  if (!Array.isArray(location)) {
+    location = [location];
+  }
+
+  do {
+    menu = menus.find(({ locations }) => locations.includes(location.shift()));
+  } while (!menu && location.length > 0);
+
+  return menu;
+}

--- a/src/lib/pages.js
+++ b/src/lib/pages.js
@@ -114,13 +114,13 @@ export async function getAllPages(options) {
 }
 
 /**
- * getNavigationPages
+ * getTopLevelPages
  */
 
-export async function getNavigationPages() {
+export async function getTopLevelPages() {
   const { pages } = await getAllPages();
 
-  const navPages = pages.filter(({ menuOrder }) => menuOrder > 0);
+  const navPages = pages.filter(({ parent }) => parent === null);
 
   return navPages;
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,20 +4,21 @@ import { SiteContext, useSiteContext } from 'hooks/use-site';
 
 import { getSiteMetadata } from 'lib/site';
 import { getRecentPosts } from 'lib/posts';
-import { getNavigationPages } from 'lib/pages';
+import { getTopLevelPages } from 'lib/pages';
 import { getCategories } from 'lib/categories';
+import { getAllMenus, createMenuFromPages, MENU_LOCATION_NAVIGATION_DEFAULT } from 'lib/menus';
 import useApolloClient from 'hooks/use-apollo-client';
 
 import 'styles/globals.scss';
 
-function App({ Component, pageProps = {}, metadata, navigation, recentPosts, categories }) {
+function App({ Component, pageProps = {}, metadata, recentPosts, categories, menus }) {
   const apolloClient = useApolloClient(pageProps.initialApolloState);
 
   const site = useSiteContext({
     metadata,
-    navigation,
     recentPosts,
     categories,
+    menus,
   });
 
   return (
@@ -38,11 +39,20 @@ App.getInitialProps = async function () {
     count: 5,
   });
 
+  const { menus } = await getAllMenus();
+
+  const defaultNavigation = createMenuFromPages({
+    locations: [MENU_LOCATION_NAVIGATION_DEFAULT],
+    pages: await getTopLevelPages(),
+  });
+
+  menus.push(defaultNavigation);
+
   return {
     metadata: await getSiteMetadata(),
-    navigation: await getNavigationPages(),
     recentPosts,
     categories,
+    menus,
   };
 };
 


### PR DESCRIPTION
This adds the ability to create new locations from within the WordPress Menus system and use them within the project.

It starts off by using the default PRIMARY navigation from WordPress, and if a menu is set to that location, uses it for the top level navigation.

Otherwise, it just displays all of the top level pages, which needless to say won't support a huge list of them.

The menus do not support children at this time.

By default, inside `next.config.js`, the primary menu is set to the ID:
```
MENU_LOCATION_NAVIGATION: 'PRIMARY',
```
But can be changed if would prefer to use another location, making this work without a location and easy to add.

Fixes #148
Fixes #7 