### PR TITLE
Add description sanitization (extra spaces) to metadata

### DIFF
--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -1,6 +1,6 @@
 import { getApolloClient } from 'lib/apollo-client';
 
-import { decodeHtmlEntities, removeLastTrailingSlash } from 'lib/util';
+import { decodeHtmlEntities, removeLastTrailingSlash, removeExtraSpaces } from 'lib/util';
 
 import { QUERY_SITE_DATA, QUERY_SEO_DATA } from 'data/site';
 
@@ -192,6 +192,8 @@ export function constructPageMetadata(defaultMetadata = {}, pageMetadata = {}, o
 export function helmetSettingsFromMetadata(metadata = {}, options = {}) {
   const { link = [], meta = [], setTitle = true } = options;
 
+  const sanitizedDescription = removeExtraSpaces(metadata.description);
+
   const settings = {
     htmlAttributes: {
       lang: metadata.language,
@@ -214,7 +216,7 @@ export function helmetSettingsFromMetadata(metadata = {}, options = {}) {
     ...meta,
     {
       name: 'description',
-      content: metadata.description,
+      content: sanitizedDescription,
     },
     {
       property: 'og:title',
@@ -222,7 +224,7 @@ export function helmetSettingsFromMetadata(metadata = {}, options = {}) {
     },
     {
       property: 'og:description',
-      content: metadata.og?.description || metadata.description,
+      content: metadata.og?.description || sanitizedDescription,
     },
     {
       property: 'og:url',
@@ -258,7 +260,7 @@ export function helmetSettingsFromMetadata(metadata = {}, options = {}) {
     },
     {
       property: 'twitter:description',
-      content: metadata.twitter?.description || metadata.og?.description || metadata.description,
+      content: metadata.twitter?.description || metadata.og?.description || sanitizedDescription,
     },
     {
       property: 'twitter:image',

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -26,3 +26,8 @@ export function removeLastTrailingSlash(url) {
   if (typeof url !== 'string') return url;
   return url.replace(/\/$/, '');
 }
+
+export function removeExtraSpaces(text) {
+  if (typeof text !== 'string') return;
+  return text.replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
### Description
If a user does not have the Yoast plugin support enabled, the description meta tag is pulled directly from the API (description field). As a user can write descriptions using spaces or paragraphs, the created tags could possibly end with that extra spaces as well.  One example could be an author writing a bio using paragraphs, that may end with meta tags replicating that spaces (image below). Also that text is replicated for `og.description` and `twitter.description`.

It is added a function that removes extra spaces at `lib/util`. As title doesnt seem to be a field where this can happen, it is applied only for description.

### Screenshots

|Before                    |
| ---------------------------------- |
|  ![before-meta](https://user-images.githubusercontent.com/50624358/116931759-cc8e7900-ac37-11eb-8483-da2eb5fde8a1.png) 

|After                      |
| ---------------------------------- |
|  ![after-meta](https://user-images.githubusercontent.com/50624358/116931744-c7c9c500-ac37-11eb-9a32-69077b42236b.png) 
