### PR TITLE
enable hierarchical/submenu feature

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -180,7 +180,7 @@ const Nav = () => {
           </Link>
         </p>
         <ul className={styles.navMenu}>
-          {navigation?.menuItems.map(({ id, path, label, title, target }) => {
+          {navigation?.map(({ id, path, label, title, target, children }) => {
             return (
               <li key={id}>
                 {!path.includes('http') && !target && (
@@ -192,6 +192,27 @@ const Nav = () => {
                   <a href={path} title={title} target={target}>
                     {label}
                   </a>
+                )}
+
+                {children?.length > 0 && (
+                  <ul className={styles.navSubMenu}>
+                    {children.map(({ id, path, label, title, target, children }) => {
+                      return (
+                        <li key={id}>
+                          {!path.includes('http') && !target && (
+                            <Link href={path}>
+                              <a title={title}>{label}</a>
+                            </Link>
+                          )}
+                          {path.includes('http') && (
+                            <a href={path} title={title} target={target}>
+                              {label}
+                            </a>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
                 )}
               </li>
             );

--- a/src/components/Nav/Nav.module.scss
+++ b/src/components/Nav/Nav.module.scss
@@ -71,6 +71,12 @@
     &:last-child {
       margin-right: 0;
     }
+
+    &:hover {
+      .navSubMenu {
+        display: block;
+      }
+    }
   }
 
   a {
@@ -83,6 +89,20 @@
     @media (hover: hover) {
       &:hover {
         color: $color-primary;
+      }
+    }
+  }
+
+  .navSubMenu {
+    background-color: #fff;
+    display: none;
+    position: absolute;
+    padding: 0;
+    list-style: none;
+
+    li {
+      &:not(:last-child) {
+        border-bottom: 1px solid $color-gray-100;
       }
     }
   }

--- a/src/data/menus.js
+++ b/src/data/menus.js
@@ -12,6 +12,7 @@ export const QUERY_ALL_MENUS = gql`
               node {
                 cssClasses
                 id
+                parentId
                 label
                 title
                 target

--- a/src/lib/menus.js
+++ b/src/lib/menus.js
@@ -63,6 +63,25 @@ export function createMenuFromPages({ locations, pages }) {
 }
 
 /**
+ * parseHierarchicalMenu
+ */
+export const parseHierarchicalMenu = (
+  data = [],
+  { idKey = 'id', parentKey = 'parentId', childrenKey = 'children' } = {}
+) => {
+  const tree = [];
+  const childrenOf = {};
+  data.forEach((item) => {
+    const newItem = { ...item };
+    const { [idKey]: id, [parentKey]: parentId = 0 } = newItem;
+    childrenOf[id] = childrenOf[id] || [];
+    newItem[childrenKey] = childrenOf[id];
+    parentId ? (childrenOf[parentId] = childrenOf[parentId] || []).push(newItem) : tree.push(newItem);
+  });
+  return tree;
+};
+
+/**
  * findMenuByLocation
  */
 
@@ -77,5 +96,5 @@ export function findMenuByLocation(menus, location) {
     menu = menus.find(({ locations }) => locations.includes(location.shift()));
   } while (!menu && location.length > 0);
 
-  return menu;
+  return parseHierarchicalMenu(menu.menuItems);
 }


### PR DESCRIPTION
We can show Submenu items based on WPGraphQl docs:
https://www.wpgraphql.com/docs/menus/#hierarchical-data.
I wrote a basic css to show/hide submenu too.
I don't know if is a good idea make it recursive. For now, we are showing first children.