### PR TITLE
Removes WORDPRESS_HOST as an environment variable option

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,4 @@
 const withPlugins = require('next-compose-plugins');
-const { removeLastTrailingSlash } = require('./plugins/util');
 
 const indexSearch = require('./plugins/search-index');
 const feed = require('./plugins/feed');
@@ -18,13 +17,9 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap], [socialImages]],
   // verbose: true,
 
   env: {
-    WORDPRESS_GRAPHQL_ENDPOINT: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),
+    WORDPRESS_GRAPHQL_ENDPOINT: process.env.WORDPRESS_GRAPHQL_ENDPOINT,
     WORDPRESS_MENU_LOCATION_NAVIGATION: process.env.WORDPRESS_MENU_LOCATION_NAVIGATION || 'PRIMARY',
     WORDPRESS_PLUGIN_SEO: parseEnvValue(process.env.WORDPRESS_PLUGIN_SEO, false),
-
-    // TODO: remove and throw warning if used instead of WORDPRESS_GRAPHQL_ENDPOINT
-
-    WORDPRESS_HOST: removeLastTrailingSlash(process.env.WORDPRESS_HOST),
 
     // By default, the number of posts per page used in pagination is 10.
     // This can be modified by setting the variable POSTS_PER_PAGE to a

--- a/plugins/feed.js
+++ b/plugins/feed.js
@@ -14,7 +14,7 @@ module.exports = function feed(nextConfig = {}) {
     generate: generateFeed,
   };
 
-  const { WORDPRESS_GRAPHQL_ENDPOINT, WORDPRESS_HOST } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -24,7 +24,6 @@ module.exports = function feed(nextConfig = {}) {
 
       config.plugins.push(
         new WebpackPluginCompiler({
-          host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
           verbose,

--- a/plugins/plugin-compiler.js
+++ b/plugins/plugin-compiler.js
@@ -1,8 +1,6 @@
 const path = require('path');
 
-const { createApolloClient, createFile, terminalColor } = require('./util');
-
-const DEFAULT_GRAPHQL_PATH = '/graphql';
+const { createApolloClient, createFile, terminalColor, removeLastTrailingSlash } = require('./util');
 
 class WebpackPlugin {
   constructor(options = {}) {
@@ -10,12 +8,7 @@ class WebpackPlugin {
   }
 
   async index(compilation, options) {
-    const { url, host, plugin, verbose = false } = options;
-    let endpoint = url;
-
-    if (!endpoint && host) {
-      endpoint = `${host}${DEFAULT_GRAPHQL_PATH}`;
-    }
+    const { url, plugin, verbose = false } = options;
 
     try {
       plugin.outputLocation = path.join(plugin.outputDirectory, plugin.outputName);
@@ -23,15 +16,14 @@ class WebpackPlugin {
       verbose && console.log(`[${plugin.name}] Compiling file ${plugin.outputLocation}`);
 
       const hasUrl = typeof url === 'string';
-      const hasHost = typeof host === 'string';
 
-      if (!hasUrl && !hasHost) {
+      if (!hasUrl) {
         throw new Error(
-          `[${plugin.name}] Failed to compile: Please check that either WORDPRESS_GRAPHQL_ENDPOINT or WORDPRESS_HOST is set and configured properly.`
+          `[${plugin.name}] Failed to compile: Please check that WORDPRESS_GRAPHQL_ENDPOINT is set and configured in your environment. WORDPRESS_HOST is no longer supported by default.`
         );
       }
 
-      const apolloClient = createApolloClient(endpoint);
+      const apolloClient = createApolloClient(removeLastTrailingSlash(url));
 
       const data = await plugin.getData(apolloClient, plugin.name, verbose);
 

--- a/plugins/search-index.js
+++ b/plugins/search-index.js
@@ -14,7 +14,7 @@ module.exports = function indexSearch(nextConfig = {}) {
     generate: generateIndexSearch,
   };
 
-  const { WORDPRESS_GRAPHQL_ENDPOINT, WORDPRESS_HOST } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -24,7 +24,6 @@ module.exports = function indexSearch(nextConfig = {}) {
 
       config.plugins.push(
         new WebpackPluginCompiler({
-          host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
           verbose,

--- a/plugins/sitemap.js
+++ b/plugins/sitemap.js
@@ -15,7 +15,7 @@ module.exports = function sitemap(nextConfig = {}) {
     postcreate: generateRobotsTxt,
   };
 
-  const { WORDPRESS_GRAPHQL_ENDPOINT, WORDPRESS_HOST } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -25,7 +25,6 @@ module.exports = function sitemap(nextConfig = {}) {
 
       config.plugins.push(
         new WebpackPluginCompiler({
-          host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
           verbose,

--- a/plugins/socialImages.js
+++ b/plugins/socialImages.js
@@ -92,7 +92,7 @@ module.exports = function sitemap(nextConfig = {}) {
     },
   };
 
-  const { WORDPRESS_GRAPHQL_ENDPOINT, WORDPRESS_HOST } = env;
+  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
@@ -102,7 +102,6 @@ module.exports = function sitemap(nextConfig = {}) {
 
       config.plugins.push(
         new WebpackPluginCompiler({
-          host: WORDPRESS_HOST,
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
           verbose,

--- a/src/lib/apollo-client.js
+++ b/src/lib/apollo-client.js
@@ -1,15 +1,6 @@
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
-import { concatPagination } from '@apollo/client/utilities';
 
 import { removeLastTrailingSlash } from 'lib/util';
-
-let apolloClient;
-
-const WORDPRESS_HOST = removeLastTrailingSlash(process.env.WORDPRESS_HOST);
-const WORDPRESS_GRAPHQL_ENDPOINT = removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT);
-
-const DEFAULT_GRAPHQL_PATH = '/graphql';
-const GRAPHQL_ENDPOINT = WORDPRESS_GRAPHQL_ENDPOINT || `${WORDPRESS_HOST}${DEFAULT_GRAPHQL_PATH}`;
 
 let client;
 
@@ -31,7 +22,7 @@ export function getApolloClient() {
 export function _createApolloClient() {
   return new ApolloClient({
     link: new HttpLink({
-      uri: GRAPHQL_ENDPOINT,
+      uri: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),
     }),
     cache: new InMemoryCache(),
   });

--- a/src/lib/categories.js
+++ b/src/lib/categories.js
@@ -34,7 +34,7 @@ export async function getAllCategories() {
 
 export async function getCategoryBySlug(slug) {
   const apolloClient = getApolloClient();
-  const apiHost = new URL(process.env.WORDPRESS_HOST || process.env.WORDPRESS_GRAPHQL_ENDPOINT).host;
+  const apiHost = new URL(process.env.WORDPRESS_GRAPHQL_ENDPOINT).host;
 
   let categoryData;
   let seoData;

--- a/src/lib/pages.js
+++ b/src/lib/pages.js
@@ -16,7 +16,7 @@ export function pagePathBySlug(slug) {
 
 export async function getPageByUri(uri) {
   const apolloClient = getApolloClient();
-  const apiHost = new URL(process.env.WORDPRESS_HOST || process.env.WORDPRESS_GRAPHQL_ENDPOINT).host;
+  const apiHost = new URL(process.env.WORDPRESS_GRAPHQL_ENDPOINT).host;
 
   let pageData;
   let seoData;

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -25,7 +25,7 @@ export function postPathBySlug(slug) {
 
 export async function getPostBySlug(slug) {
   const apolloClient = getApolloClient();
-  const apiHost = new URL(process.env.WORDPRESS_HOST || process.env.WORDPRESS_GRAPHQL_ENDPOINT).host;
+  const apiHost = new URL(process.env.WORDPRESS_GRAPHQL_ENDPOINT).host;
 
   let postData;
   let seoData;


### PR DESCRIPTION
Removes `WORDPRESS_HOST` as an option in favor of `WORDPRESS_GRAPHQL_ENDPOINT`

Added to the existing warning if a host doesn't exist, just mentioning that this won't work.

Fixes https://github.com/colbyfayock/next-wordpress-starter/issues/151