### PR TITLE
Clientside Search

### DIFF
--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -1,0 +1,9 @@
+/**
+ * getSearchData
+ */
+
+export async function getSearchData() {
+  const response = await fetch('/wp-search.json');
+  const json = await response.json();
+  return json;
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,7 +1,7 @@
 import NextApp from 'next/app';
-import { ApolloProvider } from '@apollo/client';
 
 import { SiteContext, useSiteContext } from 'hooks/use-site';
+import { SearchProvider } from 'hooks/use-search';
 
 import { getSiteMetadata } from 'lib/site';
 import { getRecentPosts } from 'lib/posts';
@@ -21,7 +21,9 @@ function App({ Component, pageProps = {}, metadata, recentPosts, categories, men
 
   return (
     <SiteContext.Provider value={site}>
-      <Component {...pageProps} />
+      <SearchProvider>
+        <Component {...pageProps} />
+      </SearchProvider>
     </SiteContext.Provider>
   );
 }

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import usePageMetadata from 'hooks/use-page-metadata';
 
 import useSearch from 'hooks/use-search';
@@ -21,9 +22,16 @@ export default function Search() {
   const { metadata } = usePageMetadata({
     metadata: {
       title,
-      description: `${results.length} result${results.length !== 1 ? 's' : ''} ${query ? `for ${query}` : ''}`,
+      description: `Search results for ${query}`,
     },
   });
 
-  return <TemplateArchive title={title} posts={results} slug={slug} metadata={metadata} />;
+  return (
+    <>
+      <Helmet>
+        <meta name="robots" content="noindex" />
+      </Helmet>
+      <TemplateArchive title={title} posts={results} slug={slug} metadata={metadata} />
+    </>
+  );
 }

--- a/src/templates/archive.js
+++ b/src/templates/archive.js
@@ -58,21 +58,25 @@ export default function TemplateArchive({
       <Section>
         <Container>
           <SectionTitle>Posts</SectionTitle>
-          <ul className={styles.posts}>
-            {posts.map((post) => {
-              return (
-                <li key={post.slug}>
-                  <PostCard post={post} options={postOptions} />
-                </li>
-              );
-            })}
-          </ul>
-          {pagination && (
-            <Pagination
-              currentPage={pagination?.currentPage}
-              pagesCount={pagination?.pagesCount}
-              basePath={pagination?.basePath}
-            />
+          {Array.isArray(posts) && (
+            <>
+              <ul className={styles.posts}>
+                {posts.map((post) => {
+                  return (
+                    <li key={post.slug}>
+                      <PostCard post={post} options={postOptions} />
+                    </li>
+                  );
+                })}
+              </ul>
+              {pagination && (
+                <Pagination
+                  currentPage={pagination?.currentPage}
+                  pagesCount={pagination?.pagesCount}
+                  basePath={pagination?.basePath}
+                />
+              )}
+            </>
           )}
         </Container>
       </Section>


### PR DESCRIPTION
Updates the search index to get fetched in the browser instead of imported. This is to help resolve errors when trying to build a fresh copy.

Moved this logic to the _app and providing the data and interface in global context to avoid multiple and conflicting indexes

Fixes https://github.com/colbyfayock/next-wordpress-starter/issues/178