### PR TITLE
Replace sass '/' deprecated operator with math.div

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ public/feed.xml
 public/sitemap.xml
 public/robots.txt
 public/images/og
+
+# VSCode settings
+.vscode/

--- a/src/components/FeaturedImage/FeaturedImage.module.scss
+++ b/src/components/FeaturedImage/FeaturedImage.module.scss
@@ -7,7 +7,7 @@
     position: relative;
     width: 100%;
     height: 0;
-    padding-top: percentage(400 / 960);
+    padding-top: percentage(math.div(400, 960));
   }
 
   img {


### PR DESCRIPTION
### Description
While testing the build for #178, I found the following warning on console:

![shot_210529_191247](https://user-images.githubusercontent.com/50624358/120086680-602c5b80-c0b7-11eb-8b45-e16707711991.png)

It seems like this operator [has been deprecated](https://sass-lang.com/documentation/breaking-changes/slash-div) and the recommended operator in replace is [math.div()](https://sass-lang.com/documentation/modules/math#div)

I also added the line to ignore VSCode settings.