### PR TITLE
Replace sass '/' deprecated operator with math.div

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ public/feed.xml
 public/sitemap.xml
 public/robots.txt
 public/images/og
+
+# VSCode settings
+.vscode/

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-helmet": "^6.1.0",
     "react-icons": "^4.2.0",
     "rss": "^1.2.2",
-    "sass": "^1.32.13",
+    "sass": "^1.34.0",
     "style.css": "^1.0.0"
   },
   "devDependencies": {

--- a/src/components/FeaturedImage/FeaturedImage.module.scss
+++ b/src/components/FeaturedImage/FeaturedImage.module.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import "styles/settings/__settings";
 
 .featuredImage {
@@ -7,7 +8,7 @@
     position: relative;
     width: 100%;
     height: 0;
-    padding-top: percentage(400 / 960);
+    padding-top: percentage(math.div(400, 960));
   }
 
   img {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3314,10 +3314,10 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@^1.32.13:
-  version "1.32.13"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.13.tgz#8d29c849e625a415bce71609c7cf95e15f74ed00"
-  integrity sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==
+sass@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.34.0.tgz#e46d5932d8b0ecc4feb846d861f26a578f7f7172"
+  integrity sha512-rHEN0BscqjUYuomUEaqq3BMgsXqQfkcMVR7UhscsAVub0/spUrZGBMxQXFS2kfiDsPLZw5yuU9iJEFNC2x38Qw==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
Fixes #184

Just sending this one I had prepared yesterday. The problem was with the `sass` package version, the math.div operator only works starting from 1.33.0 (the project is using 1.32), so I just upgrade the package to 1.34.
I think there is no [breaking changes](https://github.com/sass/dart-sass/releases) that affect other parts of the code, so the upgrade should not affect anything. 