### PR TITLE
Fix twitter card summary image

### DIFF
--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -271,7 +271,7 @@ export function helmetSettingsFromMetadata(metadata = {}, options = {}) {
       content: metadata.twitter?.username && `@${metadata.twitter.username}`,
     },
     {
-      property: 'twitter:card_type',
+      property: 'twitter:card',
       content: metadata.twitter?.cardType,
     },
     {


### PR DESCRIPTION

### Description
It fixes the meta name to make Twitter summary cards work.

![shot_210604_110505](https://user-images.githubusercontent.com/50624358/120815020-d3a1f300-c525-11eb-95c1-76cfb1211a7c.png)

That was hard to catch , I was making all kind of tests not related to the property name 😆 . 

@colbyfayock could you please check the og images of https://next-wordpress-starter.spacejelly.dev/ it seems that they have been created incorrectly: https://next-wordpress-starter.spacejelly.dev/images/og/voluptas-in-nemo-eaque-tempora-sit-quisquam.png
Probably when I sent that PR with the SASS operator change that failed?

Fixes #174