### PR TITLE
Add ESLint extension config info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ npm run dev
 
 The project should now be available at [http://localhost:3000](http://localhost:3000)!
 
+#### ESLint extension for Visual Studio Code
+
+It is possible to take advantage of this extension to improve the development experience.
+To set up the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) in Visual Studio Code add a new folder to the root `.vscode`. Inside add a file `settings.json` with the following content:
+
+```json
+{
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}
+```
+
+With this file ESLint will automatically fix and validate syntax errors and format the code on save (based on Prettier configuration).
+
 ## 🛠 Configuring Your Project
 
 ### package.json


### PR DESCRIPTION
### Description 
It adds the steps to configurate the ESLint extension in VSCode at README.

Don't remember if you agreed to have this at the README or if it was preferable to have it as a post... Feel free to close it or change anything in the description. I can save the text for the future post format, so no problem if you think is better to close this =)