### PR TITLE
Update post lib to use WP posts per page value

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,11 +21,6 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap], [socialImages]],
     WORDPRESS_MENU_LOCATION_NAVIGATION: process.env.WORDPRESS_MENU_LOCATION_NAVIGATION || 'PRIMARY',
     WORDPRESS_PLUGIN_SEO: parseEnvValue(process.env.WORDPRESS_PLUGIN_SEO, false),
 
-    // By default, the number of posts per page used in pagination is 10.
-    // This can be modified by setting the variable POSTS_PER_PAGE to a
-    // custom number.
-    // POSTS_PER_PAGE: 10,
-
     // The image directory for open graph images will be saved at the location above
     // with `public` prepended. By default, images will be saved at /public/images/og
     // and available at /images/og. If changing, make sure to update the .gitignore

--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -235,3 +235,11 @@ export const QUERY_POST_SEO_BY_SLUG = gql`
     }
   }
 `;
+
+export const QUERY_POST_PER_PAGE = gql`
+  query PostPerPage {
+    allSettings {
+      readingSettingsPostsPerPage
+    }
+  }
+`;

--- a/src/pages/posts/page/[page].js
+++ b/src/pages/posts/page/[page].js
@@ -32,7 +32,7 @@ export async function getStaticProps({ params = {} } = {}) {
 
 export async function getStaticPaths() {
   const { posts } = await getAllPosts();
-  const pagesCount = getPagesCount(posts);
+  const pagesCount = await getPagesCount(posts);
   const paths = [...new Array(pagesCount)].map((_, i) => {
     return { params: { page: String(i + 1) } };
   });


### PR DESCRIPTION
### Description
It updates the variable post per page querying `readingSettingsPostsPerPage` from WP. If the previous `POST_PER_PAGE` env variable is set, it will be used but displaying a warn reporting that it has been deprecated.

Previous thread: #176
Fixes #171