### PR TITLE
Disable Next Image component rule for ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,6 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn',
     'react/prop-types': 'off',
     'react/react-in-jsx-scope': 'off',
+    '@next/next/no-img-element': 'off',
   },
 };


### PR DESCRIPTION
### Description
Disables the Next Image component rule (warning) until it is solved how to use it at build time.

Related: #199