### PR TITLE
Update plugins to use Webpack Logger

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,17 +5,15 @@ const feed = require('./plugins/feed');
 const sitemap = require('./plugins/sitemap');
 const socialImages = require('./plugins/socialImages');
 
+// By enabling plugin debug logging, it will provide additional output details for
+// diagnostic purposes. Is disabled by default.
+// e.g., [feed, { debug: true }],
 module.exports = withPlugins([[indexSearch], [feed], [sitemap], [socialImages]], {
   // By default, Next.js removes the trailing slash. One reason this would be good
   // to include is by default, the `path` property of the router for the homepage
   // is `/` and by using that, would instantly create a redirect
 
   trailingSlash: true,
-
-  // By enabling verbose logging, it will provide additional output details for
-  // diagnostic purposes. By default is set to false.
-  // verbose: true,
-
   env: {
     WORDPRESS_GRAPHQL_ENDPOINT: process.env.WORDPRESS_GRAPHQL_ENDPOINT,
     WORDPRESS_MENU_LOCATION_NAVIGATION: process.env.WORDPRESS_MENU_LOCATION_NAVIGATION || 'PRIMARY',

--- a/plugins/feed.js
+++ b/plugins/feed.js
@@ -34,7 +34,7 @@ module.exports = function feed(nextConfig = {}) {
 
       if (debug) {
         const regex = new RegExp(plugin.name);
-        if (!config.infrastructureLogging?.debug) {
+        if (config.infrastructureLogging === undefined) {
           config.infrastructureLogging = {
             debug: [regex],
           };

--- a/plugins/feed.js
+++ b/plugins/feed.js
@@ -3,8 +3,14 @@ const { getFeedData, generateFeed } = require('./util');
 
 const WebpackPluginCompiler = require('./plugin-compiler');
 
+class FeedPlugin extends WebpackPluginCompiler {
+  constructor(options = {}) {
+    super(options);
+  }
+}
+
 module.exports = function feed(nextConfig = {}) {
-  const { env, outputDirectory, outputName, verbose = false } = nextConfig;
+  const { env, outputDirectory, outputName, debug } = nextConfig;
 
   const plugin = {
     name: 'Feed',
@@ -14,19 +20,33 @@ module.exports = function feed(nextConfig = {}) {
     generate: generateFeed,
   };
 
-  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
+  // Reset properties to avoid shared configuration
+  if (Object.prototype.hasOwnProperty.call(nextConfig, 'outputDirectory')) nextConfig.outputDirectory = undefined;
+  if (Object.prototype.hasOwnProperty.call(nextConfig, 'outputName')) nextConfig.outputName = undefined;
+  if (Object.prototype.hasOwnProperty.call(nextConfig, 'debug')) nextConfig.debug = undefined;
 
+  const { WORDPRESS_GRAPHQL_ENDPOINT } = env;
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
       if (config.watchOptions) {
         config.watchOptions.ignored.push(path.join('**', plugin.outputDirectory, plugin.outputName));
       }
 
+      if (debug) {
+        const regex = new RegExp(plugin.name);
+        if (!config.infrastructureLogging?.debug) {
+          config.infrastructureLogging = {
+            debug: [regex],
+          };
+        } else {
+          config.infrastructureLogging.debug.push(regex);
+        }
+      }
+
       config.plugins.push(
-        new WebpackPluginCompiler({
+        new FeedPlugin({
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
-          verbose,
         })
       );
 

--- a/plugins/search-index.js
+++ b/plugins/search-index.js
@@ -35,7 +35,7 @@ module.exports = function indexSearch(nextConfig = {}) {
 
       if (debug) {
         const regex = new RegExp(plugin.name);
-        if (!config.infrastructureLogging?.debug) {
+        if (config.infrastructureLogging === undefined) {
           config.infrastructureLogging = {
             debug: [regex],
           };

--- a/plugins/sitemap.js
+++ b/plugins/sitemap.js
@@ -36,7 +36,7 @@ module.exports = function sitemap(nextConfig = {}) {
 
       if (debug) {
         const regex = new RegExp(plugin.name);
-        if (!config.infrastructureLogging?.debug) {
+        if (config.infrastructureLogging === undefined) {
           config.infrastructureLogging = {
             debug: [regex],
           };

--- a/plugins/socialImages.js
+++ b/plugins/socialImages.js
@@ -117,7 +117,7 @@ module.exports = function sitemap(nextConfig = {}) {
 
       if (debug) {
         const regex = new RegExp(plugin.name);
-        if (!config.infrastructureLogging?.debug) {
+        if (config.infrastructureLogging === undefined) {
           config.infrastructureLogging = {
             debug: [regex],
           };

--- a/plugins/socialImages.js
+++ b/plugins/socialImages.js
@@ -5,6 +5,12 @@ const { getAllPosts, mkdirp } = require('./util');
 
 const WebpackPluginCompiler = require('./plugin-compiler');
 
+class SocialImagesPlugin extends WebpackPluginCompiler {
+  constructor(options = {}) {
+    super(options);
+  }
+}
+
 const pkg = require('../package.json');
 
 module.exports = function sitemap(nextConfig = {}) {
@@ -12,8 +18,13 @@ module.exports = function sitemap(nextConfig = {}) {
     env,
     outputDirectory = `./public${nextConfig.env.OG_IMAGE_DIRECTORY}`,
     outputName = '[slug].png',
-    verbose = false,
+    debug,
   } = nextConfig;
+
+  // Reset properties to avoid shared configuration
+  if (Object.prototype.hasOwnProperty.call(nextConfig, 'outputDirectory')) nextConfig.outputDirectory = undefined;
+  if (Object.prototype.hasOwnProperty.call(nextConfig, 'outputName')) nextConfig.outputName = undefined;
+  if (Object.prototype.hasOwnProperty.call(nextConfig, 'debug')) nextConfig.debug = undefined;
 
   const width = 1012;
   const height = 506;
@@ -26,69 +37,73 @@ module.exports = function sitemap(nextConfig = {}) {
     outputDirectory,
     outputName,
     getData: getAllPosts,
-    generate: ({ posts = [] }) => {
-      // Make sure our directory exists before outputting the files
+    generate: ({ posts = [] }, logger) => {
+      try {
+        // Make sure our directory exists before outputting the files
+        mkdirp(outputDirectory);
 
-      mkdirp(outputDirectory);
+        posts.forEach((post) => {
+          const { title, slug } = post;
 
-      posts.forEach((post) => {
-        const { title, slug } = post;
-
-        const canvas = new fabric.StaticCanvas(null, {
-          width,
-          height,
-          backgroundColor: 'white',
-        });
-
-        const headlineWidth = (width / 3) * 2;
-        const headlineHeight = height - padding * 2 - footerHeight;
-
-        const headline = new fabric.Textbox(title, {
-          left: (width - headlineWidth) / 2,
-          top: height / 2 - footerHeight,
-          originY: 'center',
-          width: headlineWidth,
-          height: headlineHeight,
-          fill: '#303030',
-          fontFamily: 'Arial',
-          fontWeight: 600,
-          fontSize: 60,
-          lineHeight: 1,
-          textAlign: 'center',
-        });
-
-        canvas.add(headline);
-
-        const homepage = pkg.homepage && pkg.homepage.replace(/http(s)?:\/\//, '');
-
-        if (homepage) {
-          const website = new fabric.Textbox(homepage, {
-            left: 0,
-            top: height - padding / 2 - footerHeight,
+          const canvas = new fabric.StaticCanvas(null, {
             width,
-            height: footerHeight,
+            height,
+            backgroundColor: 'white',
+          });
+
+          const headlineWidth = (width / 3) * 2;
+          const headlineHeight = height - padding * 2 - footerHeight;
+
+          const headline = new fabric.Textbox(title, {
+            left: (width - headlineWidth) / 2,
+            top: height / 2 - footerHeight,
+            originY: 'center',
+            width: headlineWidth,
+            height: headlineHeight,
             fill: '#303030',
             fontFamily: 'Arial',
             fontWeight: 600,
-            fontSize: 30,
+            fontSize: 60,
+            lineHeight: 1,
             textAlign: 'center',
           });
 
-          canvas.add(website);
-        }
+          canvas.add(headline);
 
-        canvas.renderAll();
+          const homepage = pkg.homepage && pkg.homepage.replace(/http(s)?:\/\//, '');
 
-        const outputPath = path.join(outputDirectory, outputName.replace('[slug]', slug));
-        const out = fs.createWriteStream(outputPath);
-        const stream = canvas.createPNGStream();
+          if (homepage) {
+            const website = new fabric.Textbox(homepage, {
+              left: 0,
+              top: height - padding / 2 - footerHeight,
+              width,
+              height: footerHeight,
+              fill: '#303030',
+              fontFamily: 'Arial',
+              fontWeight: 600,
+              fontSize: 30,
+              textAlign: 'center',
+            });
 
-        stream.on('data', function (chunk) {
-          out.write(chunk);
+            canvas.add(website);
+          }
+
+          canvas.renderAll();
+
+          const outputPath = path.join(outputDirectory, outputName.replace('[slug]', slug));
+          const out = fs.createWriteStream(outputPath);
+          const stream = canvas.createPNGStream();
+
+          stream.on('data', function (chunk) {
+            out.write(chunk);
+          });
         });
-      });
 
-      return false;
+        logger.log(`File generated`);
+        return false;
+      } catch (e) {
+        throw new Error(`Failed to generate: ${e.message}`);
+      }
     },
   };
 
@@ -100,11 +115,21 @@ module.exports = function sitemap(nextConfig = {}) {
         config.watchOptions.ignored.push(path.join('**', plugin.outputDirectory, plugin.outputName));
       }
 
+      if (debug) {
+        const regex = new RegExp(plugin.name);
+        if (!config.infrastructureLogging?.debug) {
+          config.infrastructureLogging = {
+            debug: [regex],
+          };
+        } else {
+          config.infrastructureLogging.debug.push(regex);
+        }
+      }
+
       config.plugins.push(
-        new WebpackPluginCompiler({
+        new SocialImagesPlugin({
           url: WORDPRESS_GRAPHQL_ENDPOINT,
           plugin,
-          verbose,
         })
       );
 

--- a/public/sitemap.jpg
+++ b/public/sitemap.jpg
@@ -1,1 +1,0 @@
-undefined


### PR DESCRIPTION
### Description
It updates plugins logging to use Webpack API. There are [several methods available](https://webpack.js.org/api/logging/#logger-methods): it is possible to use `info()`, `warn()` or `error()` for important messages and `log()` for messages only displayed when debug mode is enabled.

### Problem with plugins
While testing I realized there is a problem with the configuration: they all share the same config object. For example for the following config:
```
[indexSearch, { outputDirectory: './public/search'], [feed], [sitemap], [socialImages]
```
All plugins will create files at `./public/search`, because seems like the config object is passed sequentially from one plugin to the next. In order to fix this problem it is added a reset of the properties just after destructuring, to assure that the property will be undefined if nothing is passed. If a value is passed to other plugin it will override any previous value, so I think now is working as expected. Probably not the best approach/solution, but a quick fix for now, would love to hear your thoughs.

```
if (Object.prototype.hasOwnProperty.call(nextConfig, 'outputDirectory')) nextConfig.outputDirectory = undefined; 
if (Object.prototype.hasOwnProperty.call(nextConfig, 'outputName')) nextConfig.outputName = undefined; 
if (Object.prototype.hasOwnProperty.call(nextConfig, 'debug')) nextConfig.debug = undefined;
```
### Debug config
If a debug boolean variable is passed to the plugin config, additional logs will be displayed. Reference: https://webpack.js.org/configuration/other-options/#debug

### Named plugins
For each plugin it is created a new class extending WebpackPluginCompiler class:
```
class FeedPlugin extends WebpackPluginCompiler 
```
Just updated this part because I noticed that all plugins were pushed into webpack with same name, and maybe this could have some side effects at some point? Not sure of that, I can revert this change if you think its not necessary. (Reference: https://webpack.js.org/contribute/writing-a-plugin/#creating-a-plugin)

|Before                    |After
| ---------------------------------- | ---------------------------------- |
| ![plugins](https://user-images.githubusercontent.com/50624358/122480486-4f2e8600-cfa3-11eb-8491-55a5901b0b02.png) | ![plugins-after](https://user-images.githubusercontent.com/50624358/122480521-5eadcf00-cfa3-11eb-8b60-11e843d49ffa.png)|

Would love if you could help me testing it and any thoughts you might have about it =)

Fixes #189