### PR TITLE
Replaced field "categories" with "category" when querying a single category by slug

### DIFF
--- a/src/data/categories.js
+++ b/src/data/categories.js
@@ -17,58 +17,50 @@ export const QUERY_ALL_CATEGORIES = gql`
 `;
 
 export const QUERY_CATEGORY_BY_SLUG = gql`
-  query CategoryBySlug($slug: [String]) {
-    categories(where: { slug: $slug }, first: 10000) {
-      edges {
-        node {
-          categoryId
-          description
-          id
-          name
-          slug
-        }
-      }
+  query CategoryBySlug($slug: ID!) {
+    category(id: $slug, idType: SLUG) {
+      categoryId
+      description
+      id
+      name
+      slug
     }
   }
 `;
 
 export const QUERY_CATEGORY_SEO_BY_SLUG = gql`
-  query CategorySEOBySlug($slug: [String]) {
-    categories(where: { slug: $slug }, first: 10000) {
-      edges {
-        node {
-          id
-          seo {
-            canonical
-            metaDesc
-            metaRobotsNofollow
-            metaRobotsNoindex
-            opengraphAuthor
-            opengraphDescription
-            opengraphModifiedTime
-            opengraphPublishedTime
-            opengraphPublisher
-            opengraphTitle
-            opengraphType
-            title
-            twitterDescription
-            twitterTitle
-            twitterImage {
-              altText
-              sourceUrl
-              mediaDetails {
-                width
-                height
-              }
-            }
-            opengraphImage {
-              altText
-              sourceUrl
-              mediaDetails {
-                height
-                width
-              }
-            }
+  query CategorySEOBySlug($slug: ID!) {
+    category(id: $slug, idType: SLUG) {
+      id
+      seo {
+        canonical
+        metaDesc
+        metaRobotsNofollow
+        metaRobotsNoindex
+        opengraphAuthor
+        opengraphDescription
+        opengraphModifiedTime
+        opengraphPublishedTime
+        opengraphPublisher
+        opengraphTitle
+        opengraphType
+        title
+        twitterDescription
+        twitterTitle
+        twitterImage {
+          altText
+          sourceUrl
+          mediaDetails {
+            width
+            height
+          }
+        }
+        opengraphImage {
+          altText
+          sourceUrl
+          mediaDetails {
+            height
+            width
           }
         }
       }

--- a/src/lib/categories.js
+++ b/src/lib/categories.js
@@ -51,9 +51,7 @@ export async function getCategoryBySlug(slug) {
     throw e;
   }
 
-  // Use the first category as we should only be matching 1 with the slug
-
-  const category = categoryData?.data.categories.edges.map(({ node = {} }) => node).map(mapCategoryData)[0];
+  const category = mapCategoryData(categoryData?.data.category);
 
   // If the SEO plugin is enabled, look up the data
   // and apply it to the default settings
@@ -72,7 +70,7 @@ export async function getCategoryBySlug(slug) {
       throw e;
     }
 
-    const { seo = {} } = seoData?.data?.categories.edges.map(({ node = {} }) => node)[0];
+    const { seo = {} } = seoData?.data?.category;
 
     category.title = seo.title;
     category.description = seo.metaDesc;


### PR DESCRIPTION
Queries `QUERY_CATEGORY_BY_SLUG` and `QUERY_CATEGORY_SEO_BY_SLUG` are querying a list of categories, and then picking the first item.

But WPGraphQL can already query a single category by its slug: `{ category(id: $slug, idType: SLUG) { id } }`

So this PR replaces it