### PR TITLE
Replaced deprecated fields

### DIFF
--- a/plugins/util.js
+++ b/plugins/util.js
@@ -77,7 +77,7 @@ async function getAllPosts(apolloClient, process, verbose = false) {
           node {
             title
             excerpt
-            postId
+            databaseId
             slug
             date
             modified

--- a/src/data/categories.js
+++ b/src/data/categories.js
@@ -5,7 +5,7 @@ export const QUERY_ALL_CATEGORIES = gql`
     categories(first: 10000) {
       edges {
         node {
-          categoryId
+          databaseId
           description
           id
           name
@@ -19,7 +19,7 @@ export const QUERY_ALL_CATEGORIES = gql`
 export const QUERY_CATEGORY_BY_SLUG = gql`
   query CategoryBySlug($slug: ID!) {
     category(id: $slug, idType: SLUG) {
-      categoryId
+      databaseId
       description
       id
       name

--- a/src/data/menus.js
+++ b/src/data/menus.js
@@ -6,7 +6,6 @@ export const QUERY_ALL_MENUS = gql`
       edges {
         node {
           id
-          menuId
           menuItems {
             edges {
               node {

--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -21,7 +21,7 @@ export const QUERY_ALL_POSTS = gql`
           categories {
             edges {
               node {
-                categoryId
+                databaseId
                 id
                 name
                 slug
@@ -71,7 +71,7 @@ export const QUERY_POST_BY_SLUG = gql`
       categories {
         edges {
           node {
-            categoryId
+            databaseId
             id
             name
             slug
@@ -121,7 +121,7 @@ export const QUERY_POSTS_BY_CATEGORY_ID = gql`
           categories {
             edges {
               node {
-                categoryId
+                databaseId
                 id
                 name
                 slug
@@ -160,7 +160,7 @@ export const QUERY_POSTS_BY_AUTHOR_SLUG = gql`
           categories {
             edges {
               node {
-                categoryId
+                databaseId
                 id
                 name
                 slug

--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -42,7 +42,7 @@ export const QUERY_ALL_POSTS = gql`
             }
           }
           modified
-          postId
+          databaseId
           title
           slug
           isSticky
@@ -92,7 +92,7 @@ export const QUERY_POST_BY_SLUG = gql`
         }
       }
       modified
-      postId
+      databaseId
       title
       slug
       isSticky
@@ -142,7 +142,7 @@ export const QUERY_POSTS_BY_CATEGORY_ID = gql`
             }
           }
           modified
-          postId
+          databaseId
           title
           slug
           isSticky
@@ -181,7 +181,7 @@ export const QUERY_POSTS_BY_AUTHOR_SLUG = gql`
           }
           id
           modified
-          postId
+          databaseId
           slug
           title
           isSticky

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -278,7 +278,7 @@ export async function getRelatedPosts(category, postId, count = 5) {
   let relatedPosts = [];
 
   if (category) {
-    const { posts } = await getPostsByCategoryId(category.categoryId);
+    const { posts } = await getPostsByCategoryId(category.databaseId);
     const filtered = posts.filter(({ postId: id }) => id !== postId);
     const sorted = sortObjectsByDate(filtered);
     relatedPosts = sorted.map((post) => ({ title: post.title, slug: post.slug }));

--- a/src/pages/categories/[slug].js
+++ b/src/pages/categories/[slug].js
@@ -20,7 +20,7 @@ export default function Category({ category, posts }) {
 
 export async function getStaticProps({ params = {} } = {}) {
   const { category } = await getCategoryBySlug(params?.slug);
-  const { posts } = await getPostsByCategoryId(category.categoryId);
+  const { posts } = await getPostsByCategoryId(category.databaseId);
 
   return {
     props: {

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -146,7 +146,7 @@ export async function getStaticProps({ params = {} } = {}) {
 
   const socialImage = `${process.env.OG_IMAGE_DIRECTORY}/${params?.slug}.png`;
 
-  const { categories, postId } = post;
+  const { categories, databaseId: postId } = post;
   const category = categories.length && categories[0];
   let { name, slug } = category;
 


### PR DESCRIPTION
The following fields are deprecated:

- `Post.postId`
- `Category.categoryId`

So I replaced them with field `databaseId`.

Also `Menu.menuId` is deprecated, but I noticed that it is not used anywhere, then I removed the field from the query.