### PR TITLE
Make the menu's search by location `PRIMARY` case insensitive

### DIFF
--- a/src/lib/menus.js
+++ b/src/lib/menus.js
@@ -94,7 +94,7 @@ export function findMenuByLocation(menus, location) {
 
   do {
     menu = menus.find(function ({ locations }) {
-      return locations.map((loc) => loc.toUpperCase()).includes(location.shift().toUpperCase());
+      return locations.map((loc) => loc.toUpperCase()).includes(location.shift()?.toUpperCase());
     });
   } while (!menu && location.length > 0);
 

--- a/src/lib/menus.js
+++ b/src/lib/menus.js
@@ -98,5 +98,9 @@ export function findMenuByLocation(menus, location) {
     });
   } while (!menu && location.length > 0);
 
+  if (!menu) {
+    return null;
+  }
+
   return parseHierarchicalMenu(menu.menuItems);
 }

--- a/src/lib/menus.js
+++ b/src/lib/menus.js
@@ -93,9 +93,9 @@ export function findMenuByLocation(menus, location) {
   }
 
   do {
-    menu = menus.find(({ locations }) =>
-      locations.map((loc) => loc.toUpperCase()).includes(location.shift().toUpperCase())
-    );
+    menu = menus.find(function ({ locations }) {
+      return locations.map((loc) => loc.toUpperCase()).includes(location.shift().toUpperCase());
+    });
   } while (!menu && location.length > 0);
 
   return parseHierarchicalMenu(menu.menuItems);

--- a/src/lib/menus.js
+++ b/src/lib/menus.js
@@ -93,7 +93,9 @@ export function findMenuByLocation(menus, location) {
   }
 
   do {
-    menu = menus.find(({ locations }) => locations.includes(location.shift()));
+    menu = menus.find(({ locations }) =>
+      locations.map((loc) => loc.toUpperCase()).includes(location.shift().toUpperCase())
+    );
   } while (!menu && location.length > 0);
 
   return parseHierarchicalMenu(menu.menuItems);


### PR DESCRIPTION
Currently, the logic to search for the menu called `PRIMARY` via `includes()` is case sensitive.

However, in WordPress the menu is called `primary`, in lower case (at least for the Twenty Twenty-One theme). I do not know why WPGraphQL is returning it in uppercase, if by design or accident, but I have the impression it's not right.

So this PR makes the search case insensitive, so `PRIMARY` can be found always, even if GraphQL retrieves it as `primary`