### PR TITLE
Export Scss variables to use in UI

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -11,6 +11,7 @@ import NextNProgress from 'nextjs-progressbar';
 import { getAllMenus, createMenuFromPages, MENU_LOCATION_NAVIGATION_DEFAULT } from 'lib/menus';
 
 import 'styles/globals.scss';
+import variables from 'styles/_variables.module.scss';
 
 function App({ Component, pageProps = {}, metadata, recentPosts, categories, menus }) {
   const site = useSiteContext({
@@ -23,7 +24,7 @@ function App({ Component, pageProps = {}, metadata, recentPosts, categories, men
   return (
     <SiteContext.Provider value={site}>
       <SearchProvider>
-        <NextNProgress height={4} color="#0070F3" />
+        <NextNProgress height={4} color={variables.progressbarColor} />
         <Component {...pageProps} />
       </SearchProvider>
     </SiteContext.Provider>

--- a/src/styles/_variables.module.scss
+++ b/src/styles/_variables.module.scss
@@ -1,0 +1,5 @@
+$progressbar_color: #0070f3;
+
+:export {
+  progressbarColor: $progressbar_color;
+}


### PR DESCRIPTION
I've tried to modify webpack configuration in `next.config.js` according to the article in #247 and it gives me a warning.

If we add a custom css configuration, Next will disables the built-in CSS/SCSS support according to [this article](https://nextjs.org/docs/messages/built-in-css-disabled) which is probably undesirable.

Turns out that Next seems to support exporting Sass variables in Sass module out of the box. Thanks to [this issue](https://github.com/vercel/next.js/issues/11629) and [this PR](https://github.com/Jam3/nextjs-boilerplate/pull/49#issue-466962277)

Thanks for this fun exploration!