### PR TITLE
Fixed issue: `PRIMARY` menu is not found if it's not the 1st item in list

### DIFF
--- a/src/lib/menus.js
+++ b/src/lib/menus.js
@@ -95,7 +95,8 @@ export function findMenuByLocation(menus, location) {
 
   do {
     menu = menus.find(function ({ locations }) {
-      return locations.map((loc) => loc.toUpperCase()).includes(location.shift()?.toUpperCase());
+      const searchLocations = [...location];
+      return locations.map((loc) => loc.toUpperCase()).includes(searchLocations.shift()?.toUpperCase());
     });
   } while (!menu && location.length > 0);
 


### PR DESCRIPTION
When searching for the menu `PRIMARY`, if the menu is not the first one in the list from the response from GraphQL, then the menu will not be found. That's because `location.shift()` will make `location` be empty after the 1st item, and then the comparison will always be against the empty array for all other items in the list.

To fix it, I first duplicated `location` into `searchLocations` and then compare against that.