### PR TITLE
Convert Sitemap and Feed XML links to standard anchors

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -71,14 +71,10 @@ const Footer = () => {
                 </p>
                 <ul className={styles.footerMenuItems}>
                   <li>
-                    <Link href="/feed.xml">
-                      <a>RSS</a>
-                    </Link>
+                    <a href="/feed.xml">RSS</a>
                   </li>
                   <li>
-                    <Link href="/sitemap.xml">
-                      <a>Sitemap</a>
-                    </Link>
+                    <a href="/sitemap.xml">Sitemap</a>
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
Due to using the Next.js Link component for the Sitemap and RSS Feed, Next.js is trying to do a page lookup which is unavailable given they're externally generated and in the public folder.

This converts them to standard anchor tags, treating them like external links, to avoid the issue.

Fixes https://github.com/colbyfayock/next-wordpress-starter/issues/317