### PR TITLE
Reducing queried data where not needed

### DIFF
--- a/src/data/pages.js
+++ b/src/data/pages.js
@@ -1,23 +1,71 @@
 import { gql } from '@apollo/client';
 
-export const QUERY_ALL_PAGES = gql`
-  {
+export const PAGE_FIELDS = gql`
+  fragment PageFields on Page {
+    children {
+      edges {
+        node {
+          id
+          slug
+          uri
+          ... on Page {
+            id
+            title
+          }
+        }
+      }
+    }
+    id
+    menuOrder
+    parent {
+      node {
+        id
+        slug
+        uri
+        ... on Page {
+          title
+        }
+      }
+    }
+    slug
+    title
+    uri
+  }
+`;
+
+export const QUERY_ALL_PAGES_INDEX = gql`
+  ${PAGE_FIELDS}
+  query AllPagesIndex {
     pages(first: 10000, where: { hasPassword: false }) {
       edges {
         node {
-          children {
-            edges {
-              node {
-                id
-                slug
-                uri
-                ... on Page {
-                  id
-                  title
-                }
-              }
-            }
-          }
+          ...PageFields
+        }
+      }
+    }
+  }
+`;
+
+export const QUERY_ALL_PAGES_ARCHIVE = gql`
+  ${PAGE_FIELDS}
+  query AllPagesIndex {
+    pages(first: 10000, where: { hasPassword: false }) {
+      edges {
+        node {
+          ...PageFields
+        }
+      }
+    }
+  }
+`;
+
+export const QUERY_ALL_PAGES = gql`
+  ${PAGE_FIELDS}
+  query AllPagesIndex {
+    pages(first: 10000, where: { hasPassword: false }) {
+      edges {
+        node {
+          ...PageFields
           content
           featuredImage {
             node {
@@ -29,21 +77,6 @@ export const QUERY_ALL_PAGES = gql`
               srcSet
             }
           }
-          id
-          menuOrder
-          parent {
-            node {
-              id
-              slug
-              uri
-              ... on Page {
-                title
-              }
-            }
-          }
-          slug
-          title
-          uri
         }
       }
     }

--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -1,6 +1,68 @@
 import { gql } from '@apollo/client';
 
+export const POST_FIELDS = gql`
+  fragment PostFields on Post {
+    id
+    categories {
+      edges {
+        node {
+          databaseId
+          id
+          name
+          slug
+        }
+      }
+    }
+    databaseId
+    date
+    title
+    postId
+    slug
+  }
+`;
+
+export const QUERY_ALL_POSTS_INDEX = gql`
+  ${POST_FIELDS}
+  query AllPostsIndex {
+    posts(first: 10000, where: { hasPassword: false }) {
+      edges {
+        node {
+          ...PostFields
+        }
+      }
+    }
+  }
+`;
+
+export const QUERY_ALL_POSTS_ARCHIVE = gql`
+  ${POST_FIELDS}
+  query AllPostsArchive {
+    posts(first: 10000, where: { hasPassword: false }) {
+      edges {
+        node {
+          ...PostFields
+          author {
+            node {
+              avatar {
+                height
+                url
+                width
+              }
+              id
+              name
+              slug
+            }
+          }
+          excerpt
+          isSticky
+        }
+      }
+    }
+  }
+`;
+
 export const QUERY_ALL_POSTS = gql`
+  ${POST_FIELDS}
   query AllPosts {
     posts(first: 10000, where: { hasPassword: false }) {
       edges {
@@ -17,19 +79,7 @@ export const QUERY_ALL_POSTS = gql`
               slug
             }
           }
-          id
-          categories {
-            edges {
-              node {
-                databaseId
-                id
-                name
-                slug
-              }
-            }
-          }
           content
-          date
           excerpt
           featuredImage {
             node {
@@ -42,9 +92,6 @@ export const QUERY_ALL_POSTS = gql`
             }
           }
           modified
-          databaseId
-          title
-          slug
           isSticky
         }
       }

--- a/src/data/posts.js
+++ b/src/data/posts.js
@@ -15,9 +15,10 @@ export const POST_FIELDS = gql`
     }
     databaseId
     date
-    title
+    isSticky
     postId
     slug
+    title
   }
 `;
 
@@ -54,7 +55,6 @@ export const QUERY_ALL_POSTS_ARCHIVE = gql`
             }
           }
           excerpt
-          isSticky
         }
       }
     }
@@ -67,6 +67,7 @@ export const QUERY_ALL_POSTS = gql`
     posts(first: 10000, where: { hasPassword: false }) {
       edges {
         node {
+          ...PostFields
           author {
             node {
               avatar {
@@ -92,7 +93,6 @@ export const QUERY_ALL_POSTS = gql`
             }
           }
           modified
-          isSticky
         }
       }
     }
@@ -147,11 +147,26 @@ export const QUERY_POST_BY_SLUG = gql`
   }
 `;
 
-export const QUERY_POSTS_BY_CATEGORY_ID = gql`
+export const QUERY_POSTS_BY_CATEGORY_ID_INDEX = gql`
+  ${POST_FIELDS}
   query PostsByCategoryId($categoryId: Int!) {
     posts(where: { categoryId: $categoryId, hasPassword: false }) {
       edges {
         node {
+          ...PostFields
+        }
+      }
+    }
+  }
+`;
+
+export const QUERY_POSTS_BY_CATEGORY_ID_ARCHIVE = gql`
+  ${POST_FIELDS}
+  query PostsByCategoryId($categoryId: Int!) {
+    posts(where: { categoryId: $categoryId, hasPassword: false }) {
+      edges {
+        node {
+          ...PostFields
           author {
             node {
               avatar {
@@ -164,19 +179,33 @@ export const QUERY_POSTS_BY_CATEGORY_ID = gql`
               slug
             }
           }
-          id
-          categories {
-            edges {
-              node {
-                databaseId
-                id
-                name
-                slug
+          excerpt
+        }
+      }
+    }
+  }
+`;
+
+export const QUERY_POSTS_BY_CATEGORY_ID = gql`
+  ${POST_FIELDS}
+  query PostsByCategoryId($categoryId: Int!) {
+    posts(where: { categoryId: $categoryId, hasPassword: false }) {
+      edges {
+        node {
+          ...PostFields
+          author {
+            node {
+              avatar {
+                height
+                url
+                width
               }
+              id
+              name
+              slug
             }
           }
           content
-          date
           excerpt
           featuredImage {
             node {
@@ -189,10 +218,33 @@ export const QUERY_POSTS_BY_CATEGORY_ID = gql`
             }
           }
           modified
-          databaseId
-          title
-          slug
-          isSticky
+        }
+      }
+    }
+  }
+`;
+
+export const QUERY_POSTS_BY_AUTHOR_SLUG_INDEX = gql`
+  ${POST_FIELDS}
+  query PostByAuthorSlugIndex($slug: String!) {
+    posts(where: { authorName: $slug, hasPassword: false }) {
+      edges {
+        node {
+          ...PostFields
+        }
+      }
+    }
+  }
+`;
+
+export const QUERY_POSTS_BY_AUTHOR_SLUG_ARCHIVE = gql`
+  ${POST_FIELDS}
+  query PostByAuthorSlugArchive($slug: String!) {
+    posts(where: { authorName: $slug, hasPassword: false }) {
+      edges {
+        node {
+          ...PostFields
+          excerpt
         }
       }
     }
@@ -200,21 +252,12 @@ export const QUERY_POSTS_BY_CATEGORY_ID = gql`
 `;
 
 export const QUERY_POSTS_BY_AUTHOR_SLUG = gql`
+  ${POST_FIELDS}
   query PostByAuthorSlug($slug: String!) {
     posts(where: { authorName: $slug, hasPassword: false }) {
       edges {
         node {
-          categories {
-            edges {
-              node {
-                databaseId
-                id
-                name
-                slug
-              }
-            }
-          }
-          date
+          ...PostFields
           excerpt
           featuredImage {
             node {
@@ -226,12 +269,7 @@ export const QUERY_POSTS_BY_AUTHOR_SLUG = gql`
               srcSet
             }
           }
-          id
           modified
-          databaseId
-          slug
-          title
-          isSticky
         }
       }
     }

--- a/src/lib/pages.js
+++ b/src/lib/pages.js
@@ -1,6 +1,12 @@
 import { getApolloClient } from 'lib/apollo-client';
 
-import { QUERY_ALL_PAGES, QUERY_PAGE_BY_URI, QUERY_PAGE_SEO_BY_URI } from 'data/pages';
+import {
+  QUERY_ALL_PAGES_INDEX,
+  QUERY_ALL_PAGES_ARCHIVE,
+  QUERY_ALL_PAGES,
+  QUERY_PAGE_BY_URI,
+  QUERY_PAGE_SEO_BY_URI,
+} from 'data/pages';
 
 /**
  * pagePathBySlug
@@ -99,11 +105,19 @@ export async function getPageByUri(uri) {
  * getAllPages
  */
 
-export async function getAllPages() {
+const allPagesIncludesTypes = {
+  all: QUERY_ALL_PAGES,
+  archive: QUERY_ALL_PAGES_ARCHIVE,
+  index: QUERY_ALL_PAGES_INDEX,
+};
+
+export async function getAllPages(options = {}) {
+  const { queryIncludes = 'index' } = options;
+
   const apolloClient = getApolloClient();
 
   const data = await apolloClient.query({
-    query: QUERY_ALL_PAGES,
+    query: allPagesIncludesTypes[queryIncludes],
   });
 
   const pages = data?.data.pages.edges.map(({ node = {} }) => node).map(mapPageData);
@@ -117,8 +131,8 @@ export async function getAllPages() {
  * getTopLevelPages
  */
 
-export async function getTopLevelPages() {
-  const { pages } = await getAllPages();
+export async function getTopLevelPages(options) {
+  const { pages } = await getAllPages(options);
 
   const navPages = pages.filter(({ parent }) => parent === null);
 

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -4,6 +4,8 @@ import { updateUserAvatar } from 'lib/users';
 import { sortObjectsByDate } from 'lib/datetime';
 
 import {
+  QUERY_ALL_POSTS_INDEX,
+  QUERY_ALL_POSTS_ARCHIVE,
   QUERY_ALL_POSTS,
   QUERY_POST_BY_SLUG,
   QUERY_POSTS_BY_AUTHOR_SLUG,
@@ -116,11 +118,19 @@ export async function getPostBySlug(slug) {
  * getAllPosts
  */
 
-export async function getAllPosts() {
+const allPostsIncludesTypes = {
+  all: QUERY_ALL_POSTS,
+  archive: QUERY_ALL_POSTS_ARCHIVE,
+  index: QUERY_ALL_POSTS_INDEX,
+};
+
+export async function getAllPosts(options = {}) {
+  const { queryIncludes = 'archive' } = options;
+
   const apolloClient = getApolloClient();
 
   const data = await apolloClient.query({
-    query: QUERY_ALL_POSTS,
+    query: allPostsIncludesTypes[queryIncludes],
   });
 
   const posts = data?.data.posts.edges.map(({ node = {} }) => node);
@@ -190,8 +200,8 @@ export async function getPostsByCategoryId(categoryId) {
  * getRecentPosts
  */
 
-export async function getRecentPosts({ count }) {
-  const { posts } = await getAllPosts();
+export async function getRecentPosts({ count, ...options }) {
+  const { posts } = await getAllPosts(options);
   const sorted = sortObjectsByDate(posts);
   return {
     posts: sorted.slice(0, count),
@@ -338,8 +348,8 @@ export async function getPagesCount(posts, postsPerPage) {
  * getPaginatedPosts
  */
 
-export async function getPaginatedPosts(currentPage = 1) {
-  const { posts } = await getAllPosts();
+export async function getPaginatedPosts({ currentPage = 1, ...options } = {}) {
+  const { posts } = await getAllPosts(options);
   const postsPerPage = await getPostsPerPage();
   const pagesCount = await getPagesCount(posts, postsPerPage);
   let page = Number(currentPage);

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -323,11 +323,11 @@ export async function getRelatedPosts(categories, postId, count = 5) {
     related.posts = sorted.map((post) => ({ title: post.title, slug: post.slug }));
   }
 
-  if (!related.posts || related.posts.length === 0) {
+  if (!Array.isArray(related.posts) || related.posts.length === 0) {
     related = await getRelatedPosts(categories, postId, count);
   }
 
-  if (related.posts.length > count) {
+  if (Array.isArray(related.posts) && related.posts.length > count) {
     return related.posts.slice(0, count);
   }
 

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -8,7 +8,11 @@ import {
   QUERY_ALL_POSTS_ARCHIVE,
   QUERY_ALL_POSTS,
   QUERY_POST_BY_SLUG,
+  QUERY_POSTS_BY_AUTHOR_SLUG_INDEX,
+  QUERY_POSTS_BY_AUTHOR_SLUG_ARCHIVE,
   QUERY_POSTS_BY_AUTHOR_SLUG,
+  QUERY_POSTS_BY_CATEGORY_ID_INDEX,
+  QUERY_POSTS_BY_CATEGORY_ID_ARCHIVE,
   QUERY_POSTS_BY_CATEGORY_ID,
   QUERY_POST_SEO_BY_SLUG,
   QUERY_POST_PER_PAGE,
@@ -125,7 +129,7 @@ const allPostsIncludesTypes = {
 };
 
 export async function getAllPosts(options = {}) {
-  const { queryIncludes = 'archive' } = options;
+  const { queryIncludes = 'index' } = options;
 
   const apolloClient = getApolloClient();
 
@@ -144,20 +148,28 @@ export async function getAllPosts(options = {}) {
  * getPostsByAuthorSlug
  */
 
-export async function getPostsByAuthorSlug(slug) {
+const postsByAuthorSlugIncludesTypes = {
+  all: QUERY_POSTS_BY_AUTHOR_SLUG,
+  archive: QUERY_POSTS_BY_AUTHOR_SLUG_ARCHIVE,
+  index: QUERY_POSTS_BY_AUTHOR_SLUG_INDEX,
+};
+
+export async function getPostsByAuthorSlug({ slug, ...options }) {
+  const { queryIncludes = 'index' } = options;
+
   const apolloClient = getApolloClient();
 
   let postData;
 
   try {
     postData = await apolloClient.query({
-      query: QUERY_POSTS_BY_AUTHOR_SLUG,
+      query: postsByAuthorSlugIncludesTypes[queryIncludes],
       variables: {
         slug,
       },
     });
   } catch (e) {
-    console.log(`Failed to query post data: ${e.message}`);
+    console.log(`[posts][getPostsByAuthorSlug] Failed to query post data: ${e.message}`);
     throw e;
   }
 
@@ -172,20 +184,28 @@ export async function getPostsByAuthorSlug(slug) {
  * getPostsByCategoryId
  */
 
-export async function getPostsByCategoryId(categoryId) {
+const postsByCategoryIdIncludesTypes = {
+  all: QUERY_POSTS_BY_CATEGORY_ID,
+  archive: QUERY_POSTS_BY_CATEGORY_ID_ARCHIVE,
+  index: QUERY_POSTS_BY_CATEGORY_ID_INDEX,
+};
+
+export async function getPostsByCategoryId({ categoryId, ...options }) {
+  const { queryIncludes = 'index' } = options;
+
   const apolloClient = getApolloClient();
 
   let postData;
 
   try {
     postData = await apolloClient.query({
-      query: QUERY_POSTS_BY_CATEGORY_ID,
+      query: postsByCategoryIdIncludesTypes[queryIncludes],
       variables: {
         categoryId,
       },
     });
   } catch (e) {
-    console.log(`Failed to query post data: ${e.message}`);
+    console.log(`[posts][getPostsByCategoryId] Failed to query post data: ${e.message}`);
     throw e;
   }
 
@@ -284,20 +304,34 @@ export function mapPostData(post = {}) {
  * getRelatedPosts
  */
 
-export async function getRelatedPosts(category, postId, count = 5) {
-  let relatedPosts = [];
+export async function getRelatedPosts(categories, postId, count = 5) {
+  if (!Array.isArray(categories) || categories.length === 0) return;
 
-  if (category) {
-    const { posts } = await getPostsByCategoryId(category.databaseId);
+  let related = {
+    category: categories && categories.shift(),
+  };
+
+  if (related.category) {
+    const { posts } = await getPostsByCategoryId({
+      categoryId: related.category.databaseId,
+      queryIncludes: 'archive',
+    });
+
     const filtered = posts.filter(({ postId: id }) => id !== postId);
     const sorted = sortObjectsByDate(filtered);
-    relatedPosts = sorted.map((post) => ({ title: post.title, slug: post.slug }));
+
+    related.posts = sorted.map((post) => ({ title: post.title, slug: post.slug }));
   }
 
-  if (relatedPosts.length > count) {
-    return relatedPosts.slice(0, count);
+  if (!related.posts || related.posts.length === 0) {
+    related = await getRelatedPosts(categories, postId, count);
   }
-  return relatedPosts;
+
+  if (related.posts.length > count) {
+    return related.posts.slice(0, count);
+  }
+
+  return related;
 }
 
 /**

--- a/src/pages/[slugParent]/[[...slugChild]].js
+++ b/src/pages/[slugParent]/[[...slugChild]].js
@@ -125,7 +125,9 @@ export async function getStaticProps({ params = {} } = {}) {
   // be cached for all pages, so we can grab that and use it to create
   // our trail
 
-  const { pages } = await getAllPages();
+  const { pages } = await getAllPages({
+    queryIncludes: 'index',
+  });
 
   const breadcrumbs = getBreadcrumbsByUri(pageUri, pages);
 
@@ -138,7 +140,9 @@ export async function getStaticProps({ params = {} } = {}) {
 }
 
 export async function getStaticPaths() {
-  const { pages } = await getAllPages();
+  const { pages } = await getAllPages({
+    queryIncludes: 'index',
+  });
 
   // Take all the pages and create path params. The slugParent will always be
   // the top level parent page, where the slugChild will be an array of the

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -47,7 +47,9 @@ App.getInitialProps = async function (appContext) {
 
   const defaultNavigation = createMenuFromPages({
     locations: [MENU_LOCATION_NAVIGATION_DEFAULT],
-    pages: await getTopLevelPages(),
+    pages: await getTopLevelPages({
+      queryIncludes: 'index',
+    }),
   });
 
   menus.push(defaultNavigation);

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -36,6 +36,7 @@ App.getInitialProps = async function (appContext) {
 
   const { posts: recentPosts } = await getRecentPosts({
     count: 5,
+    queryIncludes: 'index',
   });
 
   const { categories } = await getCategories({

--- a/src/pages/authors/[slug].js
+++ b/src/pages/authors/[slug].js
@@ -38,7 +38,10 @@ export default function Author({ user, posts }) {
 
 export async function getStaticProps({ params = {} } = {}) {
   const { user } = await getUserByNameSlug(params?.slug);
-  const { posts } = await getPostsByAuthorSlug(user?.slug);
+  const { posts } = await getPostsByAuthorSlug({
+    slug: user?.slug,
+    queryIncludes: 'archive',
+  });
   return {
     props: {
       user,

--- a/src/pages/categories/[slug].js
+++ b/src/pages/categories/[slug].js
@@ -20,7 +20,10 @@ export default function Category({ category, posts }) {
 
 export async function getStaticProps({ params = {} } = {}) {
   const { category } = await getCategoryBySlug(params?.slug);
-  const { posts } = await getPostsByCategoryId(category.databaseId);
+  const { posts } = await getPostsByCategoryId({
+    categoryId: category.databaseId,
+    queryIncludes: 'archive',
+  });
 
   return {
     props: {

--- a/src/pages/categories/[slug].js
+++ b/src/pages/categories/[slug].js
@@ -20,6 +20,7 @@ export default function Category({ category, posts }) {
 
 export async function getStaticProps({ params = {} } = {}) {
   const { category } = await getCategoryBySlug(params?.slug);
+
   const { posts } = await getPostsByCategoryId({
     categoryId: category.databaseId,
     queryIncludes: 'archive',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -60,7 +60,9 @@ export default function Home({ posts, pagination }) {
 }
 
 export async function getStaticProps() {
-  const { posts, pagination } = await getPaginatedPosts();
+  const { posts, pagination } = await getPaginatedPosts({
+    queryIncludes: 'archive',
+  });
   return {
     props: {
       posts,

--- a/src/pages/posts.js
+++ b/src/pages/posts.js
@@ -19,7 +19,9 @@ export default function Posts({ posts, pagination }) {
 }
 
 export async function getStaticProps() {
-  const { posts, pagination } = await getPaginatedPosts();
+  const { posts, pagination } = await getPaginatedPosts({
+    queryIncludes: 'archive',
+  });
   return {
     props: {
       posts,

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -166,7 +166,9 @@ export async function getStaticProps({ params = {} } = {}) {
 }
 
 export async function getStaticPaths() {
-  const { posts } = await getAllPosts();
+  const { posts } = await getAllPosts({
+    queryIncludes: 'index',
+  });
 
   const paths = posts
     .filter(({ slug }) => typeof slug === 'string')

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -19,7 +19,7 @@ import FeaturedImage from 'components/FeaturedImage';
 
 import styles from 'styles/pages/Post.module.scss';
 
-export default function Post({ post, socialImage, relatedPosts }) {
+export default function Post({ post, socialImage, related }) {
   const {
     title,
     metaTitle,
@@ -62,7 +62,7 @@ export default function Post({ post, socialImage, relatedPosts }) {
     compactCategories: false,
   };
 
-  const { posts: relatedPostsList, title: relatedPostsTitle } = relatedPosts;
+  const { posts: relatedPostsList, title: relatedPostsTitle } = related || {};
 
   const helmetSettings = helmetSettingsFromMetadata(metadata);
 
@@ -112,7 +112,7 @@ export default function Post({ post, socialImage, relatedPosts }) {
       <Section className={styles.postFooter}>
         <Container>
           <p className={styles.postModified}>Last updated on {formatDate(modified)}.</p>
-          {!!relatedPostsList.length && (
+          {Array.isArray(relatedPostsList) && relatedPostsList.length > 0 && (
             <div className={styles.relatedPosts}>
               {relatedPostsTitle.name ? (
                 <span>
@@ -149,18 +149,22 @@ export async function getStaticProps({ params = {} } = {}) {
   const { categories, databaseId: postId } = post;
 
   const { category: relatedCategory, posts: relatedPosts } = await getRelatedPosts(categories, postId);
-
-  return {
-    props: {
-      post,
-      socialImage,
-      relatedPosts: {
+  const hasRelated = relatedCategory && Array.isArray(relatedPosts) && relatedPosts.length;
+  const related = !hasRelated
+    ? null
+    : {
         posts: relatedPosts,
         title: {
           name: relatedCategory.name || null,
           link: categoryPathBySlug(relatedCategory.slug),
         },
-      },
+      };
+
+  return {
+    props: {
+      post,
+      socialImage,
+      related,
     },
   };
 }

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -147,18 +147,18 @@ export async function getStaticProps({ params = {} } = {}) {
   const socialImage = `${process.env.OG_IMAGE_DIRECTORY}/${params?.slug}.png`;
 
   const { categories, databaseId: postId } = post;
-  const category = categories.length && categories[0];
-  let { name, slug } = category;
+
+  const { category: relatedCategory, posts: relatedPosts } = await getRelatedPosts(categories, postId);
 
   return {
     props: {
       post,
       socialImage,
       relatedPosts: {
-        posts: await getRelatedPosts(category, postId),
+        posts: relatedPosts,
         title: {
-          name: name || null,
-          link: categoryPathBySlug(slug),
+          name: relatedCategory.name || null,
+          link: categoryPathBySlug(relatedCategory.slug),
         },
       },
     },

--- a/src/pages/posts/page/[page].js
+++ b/src/pages/posts/page/[page].js
@@ -18,7 +18,10 @@ export default function Posts({ posts, pagination }) {
 }
 
 export async function getStaticProps({ params = {} } = {}) {
-  const { posts, pagination } = await getPaginatedPosts(params?.page);
+  const { posts, pagination } = await getPaginatedPosts({
+    currentPage: params?.page,
+    queryIncludes: 'archive',
+  });
   return {
     props: {
       posts,
@@ -31,7 +34,9 @@ export async function getStaticProps({ params = {} } = {}) {
 }
 
 export async function getStaticPaths() {
-  const { posts } = await getAllPosts();
+  const { posts } = await getAllPosts({
+    queryIncludes: 'index',
+  });
   const pagesCount = await getPagesCount(posts);
   const paths = [...new Array(pagesCount)].map((_, i) => {
     return { params: { page: String(i + 1) } };


### PR DESCRIPTION
* Reduces the data being passed in from props for Posts and Pages by creating different types of queries based on the needs
* Uses query fragments to help avoid having to repeat the same fields for each query
* Updates Related Posts to try to fallback to another category if the first category doesnt produce results

Reduced the homepage from 45kb to 5.7kb with the demo

![image](https://user-images.githubusercontent.com/1045274/151414498-ef8caec1-7254-4689-a893-690edfebf2e0.png)

Post page example from 31.6 kbto 11.7kb

![image](https://user-images.githubusercontent.com/1045274/151414620-a71944ef-144f-4ec0-8f84-083c775737e1.png)

Should help speed up builds a bit too