### PR TITLE
Fix related posts bug when empty

### DIFF
--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -324,7 +324,8 @@ export async function getRelatedPosts(categories, postId, count = 5) {
   }
 
   if (!Array.isArray(related.posts) || related.posts.length === 0) {
-    related = await getRelatedPosts(categories, postId, count);
+    const relatedPosts = await getRelatedPosts(categories, postId, count);
+    related = relatedPosts || related;
   }
 
   if (Array.isArray(related.posts) && related.posts.length > count) {

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -143,29 +143,28 @@ export default function Post({ post, socialImage, related }) {
 
 export async function getStaticProps({ params = {} } = {}) {
   const { post } = await getPostBySlug(params?.slug);
-
-  const socialImage = `${process.env.OG_IMAGE_DIRECTORY}/${params?.slug}.png`;
-
   const { categories, databaseId: postId } = post;
+
+  const props = {
+    post,
+    socialImage: `${process.env.OG_IMAGE_DIRECTORY}/${params?.slug}.png`,
+  };
 
   const { category: relatedCategory, posts: relatedPosts } = (await getRelatedPosts(categories, postId)) || {};
   const hasRelated = relatedCategory && Array.isArray(relatedPosts) && relatedPosts.length;
-  const related = !hasRelated
-    ? null
-    : {
-        posts: relatedPosts,
-        title: {
-          name: relatedCategory.name || null,
-          link: categoryPathBySlug(relatedCategory.slug),
-        },
-      };
+
+  if (hasRelated) {
+    props.related = {
+      posts: relatedPosts,
+      title: {
+        name: relatedCategory.name || null,
+        link: categoryPathBySlug(relatedCategory.slug),
+      },
+    };
+  }
 
   return {
-    props: {
-      post,
-      socialImage,
-      related,
-    },
+    props,
   };
 }
 


### PR DESCRIPTION
Resolves a bug when getting related posts where we weren't properly checking for the existence of data before trying to use a property.

Fixes #341 