### PR TITLE
On-Demand Page Rendering

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,15 +17,19 @@ module.exports = withPlugins([[indexSearch], [feed], [sitemap], [socialImages]],
   // verbose: true,
 
   env: {
-    WORDPRESS_GRAPHQL_ENDPOINT: process.env.WORDPRESS_GRAPHQL_ENDPOINT,
-    WORDPRESS_MENU_LOCATION_NAVIGATION: process.env.WORDPRESS_MENU_LOCATION_NAVIGATION || 'PRIMARY',
-    WORDPRESS_PLUGIN_SEO: parseEnvValue(process.env.WORDPRESS_PLUGIN_SEO, false),
-
     // The image directory for open graph images will be saved at the location above
     // with `public` prepended. By default, images will be saved at /public/images/og
     // and available at /images/og. If changing, make sure to update the .gitignore
 
     OG_IMAGE_DIRECTORY: '/images/og',
+
+    // By default, only render this number of post pages ahead of time, otherwise
+    // the rest will be rendered on-demand
+    POSTS_PRERENDER_COUNT: 5,
+
+    WORDPRESS_GRAPHQL_ENDPOINT: process.env.WORDPRESS_GRAPHQL_ENDPOINT,
+    WORDPRESS_MENU_LOCATION_NAVIGATION: process.env.WORDPRESS_MENU_LOCATION_NAVIGATION || 'PRIMARY',
+    WORDPRESS_PLUGIN_SEO: parseEnvValue(process.env.WORDPRESS_PLUGIN_SEO, false),
   },
 });
 

--- a/next.config.js
+++ b/next.config.js
@@ -3,9 +3,9 @@ const withPlugins = require('next-compose-plugins');
 const indexSearch = require('./plugins/search-index');
 const feed = require('./plugins/feed');
 const sitemap = require('./plugins/sitemap');
-const socialImages = require('./plugins/socialImages');
+// const socialImages = require('./plugins/socialImages'); TODO: failing to run on Netlify
 
-module.exports = withPlugins([[indexSearch], [feed], [sitemap], [socialImages]], {
+module.exports = withPlugins([[indexSearch], [feed], [sitemap]], {
   // By default, Next.js removes the trailing slash. One reason this would be good
   // to include is by default, the `path` property of the router for the homepage
   // is `/` and by using that, would instantly create a redirect

--- a/src/data/categories.js
+++ b/src/data/categories.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 export const QUERY_ALL_CATEGORIES = gql`
-  {
+  query AllCategories {
     categories(first: 10000) {
       edges {
         node {

--- a/src/data/menus.js
+++ b/src/data/menus.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 export const QUERY_ALL_MENUS = gql`
-  {
+  query AllMenus {
     menus {
       edges {
         node {

--- a/src/data/site.js
+++ b/src/data/site.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 export const QUERY_SITE_DATA = gql`
-  {
+  query SiteData {
     generalSettings {
       description
       language
@@ -11,7 +11,7 @@ export const QUERY_SITE_DATA = gql`
 `;
 
 export const QUERY_SEO_DATA = gql`
-  {
+  query SeoData {
     seo {
       webmaster {
         yandexVerify

--- a/src/data/users.js
+++ b/src/data/users.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 export const QUERY_ALL_USERS = gql`
-  {
+  query AllUsers {
     users(first: 10000) {
       edges {
         node {
@@ -26,7 +26,7 @@ export const QUERY_ALL_USERS = gql`
 `;
 
 export const QUERY_ALL_USERS_SEO = gql`
-  {
+  query AllUsersSeo {
     users(first: 10000) {
       edges {
         node {

--- a/src/lib/apollo-client.js
+++ b/src/lib/apollo-client.js
@@ -1,7 +1,6 @@
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 
 import { removeLastTrailingSlash } from 'lib/util';
-
 let client;
 
 /**
@@ -24,6 +23,15 @@ export function _createApolloClient() {
     link: new HttpLink({
       uri: removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT),
     }),
-    cache: new InMemoryCache(),
+    cache: new InMemoryCache({
+      typePolicies: {
+        RootQuery: {
+          queryType: true,
+        },
+        RootMutation: {
+          mutationType: true,
+        },
+      },
+    }),
   });
 }

--- a/src/pages/[slugParent]/[[...slugChild]].js
+++ b/src/pages/[slugParent]/[[...slugChild]].js
@@ -163,6 +163,6 @@ export async function getStaticPaths() {
 
   return {
     paths,
-    fallback: false,
+    fallback: 'blocking',
   };
 }

--- a/src/pages/authors/[slug].js
+++ b/src/pages/authors/[slug].js
@@ -1,4 +1,4 @@
-import { getAllAuthors, getUserByNameSlug, userSlugByName } from 'lib/users';
+import { getUserByNameSlug } from 'lib/users';
 import { getPostsByAuthorSlug } from 'lib/posts';
 import { AuthorJsonLd } from 'lib/json-ld';
 import usePageMetadata from 'hooks/use-page-metadata';
@@ -51,19 +51,32 @@ export async function getStaticProps({ params = {} } = {}) {
 }
 
 export async function getStaticPaths() {
-  const { authors } = await getAllAuthors();
+  // By default, we don't render any Author pages as they're
+  // we're considering them non-critical pages
 
-  const paths = authors.map((author) => {
-    const { name } = author;
-    return {
-      params: {
-        slug: userSlugByName(name),
-      },
-    };
-  });
+  // To enable pre-rendering of Author pages:
+
+  // 1. Add import to the top of the file
+  //
+  // import { getAllAuthors, userSlugByName } from 'lib/users';
+
+  // 2. Uncomment the below
+  //
+  // const { authors } = await getAllAuthors();
+
+  // const paths = authors.map((author) => {
+  //   const { name } = author;
+  //   return {
+  //     params: {
+  //       slug: userSlugByName(name),
+  //     },
+  //   };
+  // });
+
+  // 3. Update `paths` in the return statement below to reference the `paths` constant above
 
   return {
-    paths,
-    fallback: false,
+    paths: [],
+    fallback: 'blocking',
   };
 }

--- a/src/pages/categories/[slug].js
+++ b/src/pages/categories/[slug].js
@@ -1,4 +1,4 @@
-import { getAllCategories, getCategoryBySlug } from 'lib/categories';
+import { getCategoryBySlug } from 'lib/categories';
 import { getPostsByCategoryId } from 'lib/posts';
 import usePageMetadata from 'hooks/use-page-metadata';
 
@@ -35,19 +35,32 @@ export async function getStaticProps({ params = {} } = {}) {
 }
 
 export async function getStaticPaths() {
-  const { categories } = await getAllCategories();
+  // By default, we don't render any Category pages as
+  // we're considering them non-critical pages
 
-  const paths = categories.map((category) => {
-    const { slug } = category;
-    return {
-      params: {
-        slug,
-      },
-    };
-  });
+  // To enable pre-rendering of Category pages:
+
+  // 1. Add import to the top of the file
+  //
+  // import { getAllCategories, getCategoryBySlug } from 'lib/categories';
+
+  // 2. Uncomment the below
+  //
+  // const { categories } = await getAllCategories();
+
+  // const paths = categories.map((category) => {
+  //   const { slug } = category;
+  //   return {
+  //     params: {
+  //       slug,
+  //     },
+  //   };
+  // });
+
+  // 3. Update `paths` in the return statement below to reference the `paths` constant above
 
   return {
-    paths,
-    fallback: false,
+    paths: [],
+    fallback: 'blocking',
   };
 }

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -176,7 +176,7 @@ export async function getStaticPaths() {
   // most popular posts and render those instead
 
   const { posts } = await getRecentPosts({
-    count: process.env.POSTS_PRERENDER_COUNT,
+    count: process.env.POSTS_PRERENDER_COUNT, // Update this value in next.config.js!
     queryIncludes: 'index',
   });
 

--- a/src/pages/posts/[slug].js
+++ b/src/pages/posts/[slug].js
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { Helmet } from 'react-helmet';
 
-import { getPostBySlug, getAllPosts, getRelatedPosts, postPathBySlug } from 'lib/posts';
+import { getPostBySlug, getRecentPosts, getRelatedPosts, postPathBySlug } from 'lib/posts';
 import { categoryPathBySlug } from 'lib/categories';
 import { formatDate } from 'lib/datetime';
 import { ArticleJsonLd } from 'lib/json-ld';
@@ -169,7 +169,14 @@ export async function getStaticProps({ params = {} } = {}) {
 }
 
 export async function getStaticPaths() {
-  const { posts } = await getAllPosts({
+  // Only render the most recent posts to avoid spending unecessary time
+  // querying every single post from WordPress
+
+  // Tip: this can be customized to use data or analytitcs to determine the
+  // most popular posts and render those instead
+
+  const { posts } = await getRecentPosts({
+    count: process.env.POSTS_PRERENDER_COUNT,
     queryIncludes: 'index',
   });
 
@@ -183,6 +190,6 @@ export async function getStaticPaths() {
 
   return {
     paths,
-    fallback: false,
+    fallback: 'blocking',
   };
 }

--- a/src/pages/posts/page/[page].js
+++ b/src/pages/posts/page/[page].js
@@ -1,4 +1,4 @@
-import { getAllPosts, getPagesCount, getPaginatedPosts } from 'lib/posts';
+import { getPaginatedPosts } from 'lib/posts';
 import usePageMetadata from 'hooks/use-page-metadata';
 
 import TemplateArchive from 'templates/archive';
@@ -34,15 +34,30 @@ export async function getStaticProps({ params = {} } = {}) {
 }
 
 export async function getStaticPaths() {
-  const { posts } = await getAllPosts({
-    queryIncludes: 'index',
-  });
-  const pagesCount = await getPagesCount(posts);
-  const paths = [...new Array(pagesCount)].map((_, i) => {
-    return { params: { page: String(i + 1) } };
-  });
+  // By default, we don't render any Pagination pages as
+  // we're considering them non-critical pages
+
+  // To enable pre-rendering of Category pages:
+
+  // 1. Add import to the top of the file
+  //
+  // import { getAllPosts, getPagesCount } from 'lib/posts';
+
+  // 2. Uncomment the below
+  //
+  // const { posts } = await getAllPosts({
+  //   queryIncludes: 'index',
+  // });
+  // const pagesCount = await getPagesCount(posts);
+
+  // const paths = [...new Array(pagesCount)].map((_, i) => {
+  //   return { params: { page: String(i + 1) } };
+  // });
+
+  // 3. Update `paths` in the return statement below to reference the `paths` constant above
+
   return {
-    paths,
-    fallback: false,
+    paths: [],
+    fallback: 'blocking',
   };
 }


### PR DESCRIPTION
* Updates all dynamic routing to use `blocking` as the fallback for non-prerendered paths
* Removes all Category, Author, and Pagination pages from prerendering paths
* Pre-renders only the first 5 most recent posts