### PR TITLE
Fix/411 navlistitem null check

### DIFF
--- a/src/components/NavListItem/NavListItem.js
+++ b/src/components/NavListItem/NavListItem.js
@@ -9,11 +9,19 @@ const NavListItem = ({ className, item }) => {
 
   return (
     <li key={item.id}>
+      {/* 
+        Before rendering the Link component, we first check if `item.path` exists
+        and if it does not include 'http'. This prevents a TypeError when `item.path` is null.
+      */}
       {item.path && !item.path.includes('http') && !item.target && (
         <Link href={item.path} title={item.title}>
           {item.label}
         </Link>
       )}
+      {/* 
+        Before rendering the `a` tag, we first check if `item.path` exists
+        and if it includes 'http'. This prevents a TypeError when `item.path` is null.
+      */}
       {item.path && item.path.includes('http') && (
         <a href={item.path} title={item.title} target={item.target}>
           {item.label}

--- a/src/components/NavListItem/NavListItem.js
+++ b/src/components/NavListItem/NavListItem.js
@@ -9,12 +9,12 @@ const NavListItem = ({ className, item }) => {
 
   return (
     <li key={item.id}>
-      {!item.path.includes('http') && !item.target && (
+      {item.path && !item.path.includes('http') && !item.target && (
         <Link href={item.path} title={item.title}>
           {item.label}
         </Link>
       )}
-      {item.path.includes('http') && (
+      {item.path && item.path.includes('http') && (
         <a href={item.path} title={item.title} target={item.target}>
           {item.label}
         </a>


### PR DESCRIPTION
# Description

This PR addresses an issue where a TypeError would be thrown in NavListItem.js when trying to access properties of null. Specifically, it adds null checks before calling the includes method on item.path. This ensures that the application doesn't crash when item.path is null.

## Issue Ticket Number

Fixes #411
[NavListItem - Cannot read properties of null #411](https://github.com/colbyfayock/next-wordpress-starter/issues/411)

## Type of change

- ✅ Bug fix (non-breaking change which fixes an issue)

# Checklist

- ✅ I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- ✅ I have created an [issue](https://github.com/colbyfayock/next-wordpress-starter/issues) ticket for this PR
- ✅ I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/next-wordpress-starter/pulls) for the same update/change?
- ✅ I have performed a self-review of my own code
- ✅ I have run tests locally to ensure they all pass
- ✅ I have commented my code, particularly in hard-to-understand areas
- ✅ I have made corresponding changes needed to the documentation
